### PR TITLE
Fix root's invalid check

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -266,6 +266,11 @@ impl DoubleArrayAhoCorasickBuilder {
             self.extras[base].used_base = true;
         }
 
+        // If the root block has not been closed, it has to be closed for setting CHECK[0] to a valid value.
+        if self.states.len() <= FREE_STATES {
+            self.close_block(0);
+        }
+
         while self.head_idx != std::usize::MAX {
             let block_idx = self.head_idx / BLOCK_LEN;
             self.close_block(block_idx);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -810,6 +810,45 @@ mod tests {
     }
 
     #[test]
+    fn test_dump_root_state() {
+        let patterns: Vec<Vec<u8>> = (1..=255).map(|c| vec![c]).collect();
+        let pma = DoubleArrayAhoCorasick::new(&patterns).unwrap();
+        assert!(pma.get_child_index(0, 0).is_none());
+        for c in 1..=255 {
+            assert_eq!(pma.get_child_index(0, c).unwrap(), c as usize);
+        }
+    }
+
+    #[test]
+    fn test_dump_states_random() {
+        for _ in 0..100 {
+            let mut patterns = HashSet::new();
+            for _ in 0..100 {
+                patterns.insert(generate_random_string(8));
+            }
+            let patterns_vec: Vec<_> = patterns.into_iter().collect();
+            let pma = DoubleArrayAhoCorasick::new(&patterns_vec).unwrap();
+
+            let mut visitor = vec![0 as usize];
+            let mut visited = vec![false; pma.states.len()];
+
+            while let Some(idx) = visitor.pop() {
+                assert!(!visited[idx]);
+                assert!(
+                    pma.states[idx].base() != BASE_INVALID
+                        || pma.states[idx].output_pos() != OUTPOS_INVALID
+                );
+                visited[idx] = true;
+                for c in 0..=255 {
+                    if let Some(child_idx) = pma.get_child_index(idx, c) {
+                        visitor.push(child_idx);
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
     fn test_serialization() {
         let patterns: Vec<String> = {
             let mut patterns = HashSet::new();


### PR DESCRIPTION
To avoid invalid transitions, `DoubleArrayAhoCorasickBuilder::close_block` embeds valid values in unused `check` elements.

However, in the previous version, the `check` of the root state can have an invalid value, because `close_block` can ignore the root state by the following if-statement:


```rust
fn close_block(&mut self, block_idx: usize) {
    ...
   // The following condition means `block_idx`-th block does not have unused states.
   // That is, if the first block does not have unused states, the root state will be ignored.
    if self.head_idx >= end_idx {
        return;
    }
    ...
}
```

Since the `check` of the root state has `0` value in default, errors could occur with binary strings in the previous version.

In this PR, I fixed the bug and added new test codes with binary strings.