### PR TITLE
Add fst and yada to benchmark

### DIFF
--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -9,6 +9,8 @@ edition = "2018"
 aho-corasick = "0.7"  # Unlicense or MIT
 criterion = { version = "0.3", features = ["html_reports"] }  # Apache-2.0 or MIT
 daachorse = { path = ".." }  # Apache-2.0 or MIT
+yada = "0.4"
+fst = "0.4"
 
 [[bench]]
 name = "benchmark"


### PR DESCRIPTION
I added `fst` and `yada` to the benchmarks for `build` and `find_overlapping`.
`find` was ignored because `yada` does not provide such an operation.