### PR TITLE
Replace structopt with clap

### DIFF
--- a/daacfind/Cargo.toml
+++ b/daacfind/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+clap = { version = "3.1", features = ["derive"] }  # MIT or Apache-2.0
 daachorse = { path = ".." }  # MIT or Apache-2.0
-structopt = "0.3"  # MIT or Apache-2.0
 termcolor = "1.1"  # Unlicense or MIT


### PR DESCRIPTION
This branch replaces structopt with clap.
structopt is a wrapper of clap, but its features are integrated into clap version 3.