### PR TITLE
Add `n_free_blocks()` option

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -376,8 +376,10 @@ impl DoubleArrayAhoCorasickBuilder {
 
     fn init_array(&mut self) {
         self.states.resize(BLOCK_LEN as usize, State::default());
-        self.extras
-            .resize((BLOCK_LEN * self.num_free_blocks) as usize, Extra::default());
+        self.extras.resize(
+            (BLOCK_LEN * self.num_free_blocks) as usize,
+            Extra::default(),
+        );
         self.head_idx = ROOT_STATE_IDX;
 
         for i in 0..BLOCK_LEN {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -12,8 +12,6 @@ const BLOCK_LEN: u32 = BLOCK_MAX as u32 + 1;
 const FREE_BLOCKS: u32 = 16;
 // The number of last states (or elements) to be searched in `DoubleArrayAhoCorasickBuilder::find_base`.
 const FREE_STATES: u32 = BLOCK_LEN * FREE_BLOCKS;
-// The initial capacity to build a double array.
-const INIT_CAPACITY: u32 = 1 << 16;
 
 // Specialized [`NfaBuilder`] handling labels of `u8`.
 type BytewiseNfaBuilder = NfaBuilder<u8>;
@@ -117,9 +115,8 @@ impl DoubleArrayAhoCorasickBuilder {
     /// assert_eq!(None, it.next());
     /// ```
     pub fn new() -> Self {
-        let init_capa = BLOCK_LEN.min(INIT_CAPACITY / BLOCK_LEN * BLOCK_LEN);
         Self {
-            states: Vec::with_capacity(init_capa as usize),
+            states: vec![],
             extras: [Extra::default(); FREE_STATES as usize],
             head_idx: DEAD_STATE_IDX,
             match_kind: MatchKind::Standard,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -153,7 +153,8 @@ impl DoubleArrayAhoCorasickBuilder {
 
     /// Specifies the number of last blocks to search bases.
     ///
-    /// When the RAM capacity is small, this should be a small value.
+    /// The smaller the number is, the faster the construction time will be;
+    /// however, the memory efficiency can be degraded.
     ///
     /// # Arguments
     ///

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -156,6 +156,10 @@ impl DoubleArrayAhoCorasickBuilder {
     /// The smaller the number is, the faster the construction time will be;
     /// however, the memory efficiency can be degraded.
     ///
+    /// A fixed length of memory is allocated in proportion to this value in construction.
+    /// If an allocation error occurs during building the automaton even though the pattern set is
+    /// small, try setting a smaller value.
+    ///
     /// # Arguments
     ///
     /// * `n` - The number of last blocks.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -79,7 +79,7 @@ pub struct DoubleArrayAhoCorasickBuilder {
     extras: Vec<Extra>,
     head_idx: u32,
     match_kind: MatchKind,
-    n_free_blocks: u32,
+    num_free_blocks: u32,
 }
 
 impl Default for DoubleArrayAhoCorasickBuilder {
@@ -117,7 +117,7 @@ impl DoubleArrayAhoCorasickBuilder {
             extras: vec![],
             head_idx: DEAD_STATE_IDX,
             match_kind: MatchKind::Standard,
-            n_free_blocks: 16,
+            num_free_blocks: 16,
         }
     }
 
@@ -163,9 +163,9 @@ impl DoubleArrayAhoCorasickBuilder {
     ///
     /// `n` must be greater than or equal to 1.
     #[must_use]
-    pub const fn n_free_blocks(mut self, n: u32) -> Self {
+    pub const fn num_free_blocks(mut self, n: u32) -> Self {
         assert!(n >= 1);
-        self.n_free_blocks = n;
+        self.num_free_blocks = n;
         self
     }
 
@@ -376,7 +376,7 @@ impl DoubleArrayAhoCorasickBuilder {
     fn init_array(&mut self) {
         self.states.resize(BLOCK_LEN as usize, State::default());
         self.extras
-            .resize((BLOCK_LEN * self.n_free_blocks) as usize, Extra::default());
+            .resize((BLOCK_LEN * self.num_free_blocks) as usize, Extra::default());
         self.head_idx = ROOT_STATE_IDX;
 
         for i in 0..BLOCK_LEN {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -111,7 +111,7 @@ impl DoubleArrayAhoCorasickBuilder {
     ///
     /// assert_eq!(None, it.next());
     /// ```
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             states: vec![],
             extras: vec![],
@@ -367,7 +367,8 @@ impl DoubleArrayAhoCorasickBuilder {
 
     fn init_array(&mut self) {
         self.states.resize(BLOCK_LEN as usize, State::default());
-        self.extras.resize((BLOCK_LEN * self.n_free_blocks) as usize, Extra::default());
+        self.extras
+            .resize((BLOCK_LEN * self.n_free_blocks) as usize, Extra::default());
         self.head_idx = ROOT_STATE_IDX;
 
         for i in 0..BLOCK_LEN {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -461,7 +461,8 @@ impl DoubleArrayAhoCorasickBuilder {
 
         // It is necessary to close the head block before appending a new block
         // so that the builder works in extras[..FREE_STATES].
-        if self.extras.len() as u32 <= old_len {
+        if self.extras.len() <= old_len as usize {
+            #[allow(clippy::cast_possible_truncation)]
             self.close_block((old_len - self.extras.len() as u32) / BLOCK_LEN);
         }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -154,6 +154,14 @@ impl DoubleArrayAhoCorasickBuilder {
     /// Specifies the number of last blocks to search bases.
     ///
     /// When the RAM capacity is small, this should be a small value.
+    ///
+    /// # Arguments
+    ///
+    /// * `n` - The number of last blocks.
+    ///
+    /// # Panics
+    ///
+    /// `n` must be greater than or equal to 1.
     #[must_use]
     pub const fn n_free_blocks(mut self, n: u32) -> Self {
         assert!(n >= 1);

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -151,6 +151,9 @@ impl DoubleArrayAhoCorasickBuilder {
         self
     }
 
+    /// Specifies the number of last blocks to search bases.
+    ///
+    /// When the RAM capacity is small, this should be a small value.
     #[must_use]
     pub const fn n_free_blocks(mut self, n: u32) -> Self {
         assert!(n >= 1);

--- a/src/charwise/builder.rs
+++ b/src/charwise/builder.rs
@@ -7,9 +7,6 @@ use crate::nfa_builder::NfaBuilder;
 use crate::charwise::{DEAD_STATE_IDX, OUTPUT_POS_INVALID, ROOT_STATE_IDX};
 use crate::nfa_builder::{DEAD_STATE_ID, ROOT_STATE_ID, VALUE_INVALID};
 
-// The initial capacity to build a double array.
-const INIT_CAPACITY: u32 = 1 << 16;
-
 // Specialized [`NfaBuilder`] handling labels of `char`.
 type CharwiseNfaBuilder = NfaBuilder<char>;
 
@@ -50,7 +47,7 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
     /// ```
     pub fn new() -> Self {
         Self {
-            states: Vec::with_capacity(INIT_CAPACITY as usize),
+            states: vec![],
             match_kind: MatchKind::Standard,
         }
     }

--- a/src/charwise/builder.rs
+++ b/src/charwise/builder.rs
@@ -45,7 +45,7 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
     ///
     /// assert_eq!(None, it.next());
     /// ```
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             states: vec![],
             match_kind: MatchKind::Standard,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,6 +148,9 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(target_pointer_width = "16")]
+compile_error!("`target_pointer_width` must be larger than or equal to 32");
+
 #[macro_use]
 extern crate alloc;
 


### PR DESCRIPTION
This branch removes the following constants:
 * `INIT_CAPACITY`: `states` is initialized by `with_capacity()` with this value, but it is often reallocated for a large automaton. On the other hand, this capacity is too large for small devices.
 * `FREE_BLOCKS` and `FREE_STATES`: Some small devices do not have enough memory, so I added an option to change these parameters.