### PR TITLE
Fix keywords

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 homepage = "https://github.com/legalforce-research/daachorse"
 repository = "https://github.com/legalforce-research/daachorse"
 readme = "README.md"
-keywords = ["string", "search", "text", "aho", "multi", "double-array"]
+keywords = ["search", "text", "aho", "multi", "double-array"]
 categories = ["text-processing", "algorithms", "data-structures", "no-std"]
 exclude = [".*"]
 


### PR DESCRIPTION
crates.io allows at most 5 keywords, so this branch removes one keyword.