### PR TITLE
Fix document for standard non-overlap matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,10 @@ assert_eq!((1, 4, 0), (m.start(), m.end(), m.value()));
 assert_eq!(None, it.next());
 ```
 
-### Finding non-overlapped occurrences with shortest matching
+### Finding non-overlapped occurrences with standard matching
 
 If you do not want to allow positional overlap, use `find_iter()` instead.
-It reports the first pattern found in each iteration,
-which is the shortest pattern starting from each search position.
+It performs the search on the Aho-Corasick automaton and reports patterns first found in each iteration.
 
 ```rust
 use daachorse::DoubleArrayAhoCorasick;

--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ assert_eq!(None, it.next());
 ### Finding non-overlapped occurrences with standard matching
 
 If you do not want to allow positional overlap, use `find_iter()` instead.
-It performs the search on the Aho-Corasick automaton and reports patterns first found in each iteration.
+It performs the search on the Aho-Corasick automaton
+and reports patterns first found in each iteration.
 
 ```rust
 use daachorse::DoubleArrayAhoCorasick;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,13 +42,13 @@
 //! assert_eq!(None, it.next());
 //! ```
 //!
-//! ## Example: Finding non-overlapped occurrences with shortest matching
+//! ## Example: Finding non-overlapped occurrences with standard matching
 //!
 //! If you do not want to allow positional overlap,
 //! use [`DoubleArrayAhoCorasick::find_iter()`] instead.
 //!
-//! It reports the first pattern found in each iteration,
-//! which is the shortest pattern starting from each search position.
+//! It performs the search on the Aho-Corasick automaton and
+//! reports patterns first found in each iteration.
 //!
 //! ```
 //! use daachorse::DoubleArrayAhoCorasick;


### PR DESCRIPTION
In the previous version, we call non-overlap matching with standard algorithm *shortest matching*.
But, this naming is misleading.

For example, given a text `babc` and patterns `ab|abc|bab`, the option reports `bab`, not shorter `ab`.

This PR fixed the description.