### PR TITLE
Add forest representation of output sets

### DIFF
--- a/src/charwise.rs
+++ b/src/charwise.rs
@@ -752,7 +752,7 @@ impl CharwiseDoubleArrayAhoCorasick {
         let outputs_len = u32::from_le_bytes(outputs_len_array) as usize;
         let mut outputs = Vec::with_capacity(outputs_len);
         for _ in 0..outputs_len {
-            let mut output_array = [0; 8];
+            let mut output_array = [0; 12];
             rdr.read_exact(&mut output_array)?;
             outputs.push(Output::deserialize(output_array));
         }

--- a/src/charwise.rs
+++ b/src/charwise.rs
@@ -312,7 +312,7 @@ impl CharwiseDoubleArrayAhoCorasick {
             haystack: unsafe { CharWithEndOffsetIterator::new(StrIterator::new(haystack)) },
             state_id: ROOT_STATE_IDX,
             pos: 0,
-            output_pos: 0,
+            output_pos: OUTPUT_POS_INVALID as usize,
         }
     }
 
@@ -370,7 +370,7 @@ impl CharwiseDoubleArrayAhoCorasick {
             haystack: CharWithEndOffsetIterator::new(haystack),
             state_id: ROOT_STATE_IDX,
             pos: 0,
-            output_pos: 0,
+            output_pos: OUTPUT_POS_INVALID as usize,
         }
     }
 
@@ -607,7 +607,7 @@ impl CharwiseDoubleArrayAhoCorasick {
     /// let patterns = vec!["bcd", "ab", "a"];
     /// let pma = CharwiseDoubleArrayAhoCorasick::new(patterns).unwrap();
     ///
-    /// assert_eq!(pma.heap_bytes(), 144);
+    /// assert_eq!(pma.heap_bytes(), 148);
     /// ```
     pub fn heap_bytes(&self) -> usize {
         self.states.len() * mem::size_of::<State>() + self.outputs.len() * mem::size_of::<Output>()
@@ -827,8 +827,8 @@ impl CharwiseDoubleArrayAhoCorasick {
         source = &source[4..];
         let mut outputs = Vec::with_capacity(outputs_len);
         for _ in 0..outputs_len {
-            outputs.push(Output::deserialize(source[0..8].try_into().unwrap()));
-            source = &source[8..];
+            outputs.push(Output::deserialize(source[0..12].try_into().unwrap()));
+            source = &source[12..];
         }
 
         let match_kind = MatchKind::from(source[0]);

--- a/src/charwise/iter.rs
+++ b/src/charwise/iter.rs
@@ -16,6 +16,7 @@ impl<P> StrIterator<P>
 where
     P: AsRef<str>,
 {
+    #[allow(clippy::missing_const_for_fn)]
     pub(crate) fn new(inner: P) -> Self {
         Self { inner, pos: 0 }
     }

--- a/src/charwise/iter.rs
+++ b/src/charwise/iter.rs
@@ -131,9 +131,8 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         // self.output_pos is always smaller than self.pma.outputs.len() because
         // State::output_pos() ensures to return such a value when it is Some.
-        let out = unsafe { self.pma.outputs.get_unchecked(self.output_pos) };
-        if !out.is_begin() {
-            self.output_pos += 1;
+        if let Some(out) = self.pma.outputs.get(self.output_pos) {
+            self.output_pos = out.parent() as usize;
             return Some(Match {
                 length: out.length() as usize,
                 end: self.pos,
@@ -157,8 +156,8 @@ where
                     .get_unchecked(self.state_id as usize)
                     .output_pos()
             } {
-                self.output_pos = output_pos as usize + 1;
                 let out = unsafe { self.pma.outputs.get_unchecked(output_pos as usize) };
+                self.output_pos = out.parent() as usize;
                 return Some(Match {
                     length: out.length() as usize,
                     end: pos,

--- a/src/charwise/iter.rs
+++ b/src/charwise/iter.rs
@@ -130,8 +130,6 @@ where
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
-        // self.output_pos is always smaller than self.pma.outputs.len() because
-        // State::output_pos() ensures to return such a value when it is Some.
         if let Some(out) = self.pma.outputs.get(self.output_pos) {
             self.output_pos = out.parent() as usize;
             return Some(Match {

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -16,6 +16,7 @@ impl<P> U8SliceIterator<P>
 where
     P: AsRef<[u8]>,
 {
+    #[allow(clippy::missing_const_for_fn)]
     pub(crate) fn new(inner: P) -> Self {
         Self { inner, pos: 0 }
     }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -92,8 +92,6 @@ where
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
-        // self.output_pos is always smaller than self.pma.outputs.len() because
-        // State::output_pos() ensures to return such a value when it is Some.
         if let Some(out) = self.pma.outputs.get(self.output_pos) {
             self.output_pos = out.parent() as usize;
             return Some(Match {

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -93,9 +93,8 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         // self.output_pos is always smaller than self.pma.outputs.len() because
         // State::output_pos() ensures to return such a value when it is Some.
-        let out = unsafe { self.pma.outputs.get_unchecked(self.output_pos) };
-        if !out.is_begin() {
-            self.output_pos += 1;
+        if let Some(out) = self.pma.outputs.get(self.output_pos) {
+            self.output_pos = out.parent() as usize;
             return Some(Match {
                 length: out.length() as usize,
                 end: self.pos,
@@ -113,8 +112,8 @@ where
                     .output_pos()
             } {
                 self.pos = pos + 1;
-                self.output_pos = output_pos as usize + 1;
                 let out = unsafe { self.pma.outputs.get_unchecked(output_pos as usize) };
+                self.output_pos = out.parent() as usize;
                 return Some(Match {
                     length: out.length() as usize,
                     end: self.pos,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -631,7 +631,7 @@ impl DoubleArrayAhoCorasick {
             pma: self,
             haystack: U8SliceIterator::new(haystack).enumerate(),
             state_id: ROOT_STATE_IDX,
-            output_pos: 0,
+            output_pos: OUTPUT_POS_INVALID as usize,
             pos: 0,
         }
     }
@@ -682,7 +682,7 @@ impl DoubleArrayAhoCorasick {
             pma: self,
             haystack: haystack.enumerate(),
             state_id: ROOT_STATE_IDX,
-            output_pos: 0,
+            output_pos: OUTPUT_POS_INVALID as usize,
             pos: 0,
         }
     }
@@ -882,7 +882,7 @@ impl DoubleArrayAhoCorasick {
     /// let patterns = vec!["bcd", "ab", "a"];
     /// let pma = DoubleArrayAhoCorasick::new(patterns).unwrap();
     ///
-    /// assert_eq!(pma.heap_bytes(), 3104);
+    /// assert_eq!(pma.heap_bytes(), 3108);
     /// ```
     pub fn heap_bytes(&self) -> usize {
         self.states.len() * mem::size_of::<State>() + self.outputs.len() * mem::size_of::<Output>()
@@ -1118,8 +1118,8 @@ impl DoubleArrayAhoCorasick {
         source = &source[4..];
         let mut outputs = Vec::with_capacity(outputs_len);
         for _ in 0..outputs_len {
-            outputs.push(Output::deserialize(source[0..8].try_into().unwrap()));
-            source = &source[8..];
+            outputs.push(Output::deserialize(source[0..12].try_into().unwrap()));
+            source = &source[12..];
         }
 
         let match_kind = MatchKind::from(source[0]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,7 +285,7 @@ impl core::fmt::Debug for State {
     }
 }
 
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
 struct Output {
     value: u32,
     length: u32,
@@ -333,16 +333,6 @@ impl Output {
             length: u32::from_le_bytes(input[4..8].try_into().unwrap()),
             parent: u32::from_le_bytes(input[8..12].try_into().unwrap()),
         }
-    }
-}
-
-impl core::fmt::Debug for Output {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Output")
-            .field("value", &self.value())
-            .field("length", &self.length())
-            .field("parent", &self.parent())
-            .finish()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,7 +294,7 @@ struct Output {
 
 impl Output {
     #[inline(always)]
-    pub fn new(value: u32, length: u32, parent: u32) -> Self {
+    pub const fn new(value: u32, length: u32, parent: u32) -> Self {
         Self {
             value,
             length,

--- a/src/nfa_builder.rs
+++ b/src/nfa_builder.rs
@@ -247,25 +247,8 @@ where
         Ok(())
     }
 
-    fn set_dummy_outputs(&mut self, q: &[u32], processed: &[bool]) {
-        for &state_id in q {
-            let state_id = state_id as usize;
-            let s = &mut self.states[state_id].borrow_mut();
-            if processed[state_id] {
-                debug_assert_ne!(s.output_pos, OUTPUT_POS_INVALID);
-                continue;
-            }
-            debug_assert_eq!(s.output_pos, OUTPUT_POS_INVALID);
-            debug_assert_eq!(s.output.0, VALUE_INVALID);
-
-            let fail_id = s.fail;
-            if fail_id != DEAD_STATE_ID {
-                s.output_pos = self.states[fail_id as usize].borrow().output_pos;
-            }
-        }
-    }
-
     #[inline(always)]
+    #[allow(clippy::missing_const_for_fn)]
     fn check_outputs_error(outputs: &[Output]) -> Result<()> {
         if outputs.len() > OUTPUT_POS_INVALID as usize {
             Err(DaachorseError::automaton_scale(


### PR DESCRIPTION
This PR improved the data structure for output sets, which stores output sets on a forest representation.

The new forest representation reduces the memory usage on UniDic, as follows.

```
# old version
== data/words_100000 ==
daachorse (bytewise): 8700816 bytes, 8.298 MiB
daachorse (charwise): 11210880 bytes, 10.692 MiB
== data/unidic/unidic ==
daachorse (bytewise): 36382056 bytes, 34.697 MiB
daachorse (charwise): 30220136 bytes, 28.820 MiB

# new version
== data/words_100000 ==
daachorse (bytewise): 8999820 bytes, 8.583 MiB
daachorse (charwise): 11509884 bytes, 10.977 MiB
== data/unidic/unidic ==
daachorse (bytewise): 29523252 bytes, 28.156 MiB
daachorse (charwise): 23361332 bytes, 22.279 MiB
```

There is no significant difference in matching time.

```
unidic/find_overlapping/daachorse                                                                           
                        time:   [11.510 ms 11.541 ms 11.596 ms]
                        change: [-0.7825% -0.4400% +0.0661%] (p = 0.04 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 30 measurements (3.33%)
  1 (3.33%) high severe
unidic/find_overlapping/daachorse/charwise                                                                            
                        time:   [6.5334 ms 6.5553 ms 6.5945 ms]
                        change: [-2.5997% -2.2480% -1.6692%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 30 measurements (3.33%)
  1 (3.33%) high severe

words_100000/find_overlapping/daachorse                                                                            
                        time:   [4.3369 ms 4.3394 ms 4.3422 ms]
                        change: [+2.3980% +2.4814% +2.5662%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 30 measurements (3.33%)
  1 (3.33%) high mild
words_100000/find_overlapping/daachorse/charwise                                                                            
                        time:   [4.7484 ms 4.7626 ms 4.7781 ms]
                        change: [+3.1210% +3.5562% +3.9811%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 30 measurements (3.33%)
  1 (3.33%) high mild
```