### PR TITLE
Add code mapper in frequency order

### DIFF
--- a/bench/benches/benchmark.rs
+++ b/bench/benches/benchmark.rs
@@ -16,6 +16,18 @@ const SEARCH_SAMPLE_SIZE: usize = 30;
 const SEARCH_WARM_UP_TIME: Duration = Duration::from_secs(5);
 const SEARCH_MEASURE_TIME: Duration = Duration::from_secs(10);
 
+fn criterion_unidic_build(c: &mut Criterion) {
+    let mut group = c.benchmark_group("unidic/build");
+    group.sample_size(BUILD_SAMPLE_SIZE);
+    group.warm_up_time(BUILD_WARM_UP_TIME);
+    group.measurement_time(BUILD_MEASURE_TIME);
+    group.sampling_mode(SamplingMode::Flat);
+    let mut patterns = load_file("data/unidic/unidic");
+    patterns.sort_unstable();
+
+    add_build_benches(&mut group, &patterns);
+}
+
 fn criterion_words100000_build(c: &mut Criterion) {
     let mut group = c.benchmark_group("words_100000/build");
     group.sample_size(BUILD_SAMPLE_SIZE);
@@ -595,6 +607,7 @@ criterion_group!(
     criterion_unidic_find_overlapping,
     criterion_unidic_leftmost_longest_find,
     criterion_unidic_leftmost_first_find,
+    criterion_unidic_build,
     criterion_words100000_find,
     criterion_words100000_find_overlapping,
     criterion_words100000_leftmost_longest_find,

--- a/src/charwise.rs
+++ b/src/charwise.rs
@@ -45,7 +45,7 @@
 
 mod builder;
 pub mod iter;
-mod mapper;
+pub(crate) mod mapper;
 
 #[cfg(feature = "std")]
 use std::io::{self, Read, Write};

--- a/src/charwise.rs
+++ b/src/charwise.rs
@@ -45,6 +45,7 @@
 
 mod builder;
 pub mod iter;
+mod mapper;
 
 #[cfg(feature = "std")]
 use std::io::{self, Read, Write};
@@ -58,6 +59,7 @@ use crate::charwise::iter::{
     CharWithEndOffsetIterator, FindIterator, FindOverlappingIterator,
     FindOverlappingNoSuffixIterator, LestmostFindIterator, StrIterator,
 };
+use crate::charwise::mapper::CodeMapper;
 use crate::errors::Result;
 use crate::{MatchKind, Output};
 
@@ -85,6 +87,7 @@ pub(crate) const DEAD_STATE_IDX: u32 = 1;
 #[derive(Clone)]
 pub struct CharwiseDoubleArrayAhoCorasick {
     states: Vec<State>,
+    mapper: CodeMapper,
     outputs: Vec<Output>,
     match_kind: MatchKind,
     num_states: usize,
@@ -607,10 +610,12 @@ impl CharwiseDoubleArrayAhoCorasick {
     /// let patterns = vec!["bcd", "ab", "a"];
     /// let pma = CharwiseDoubleArrayAhoCorasick::new(patterns).unwrap();
     ///
-    /// assert_eq!(pma.heap_bytes(), 148);
+    /// assert_eq!(pma.heap_bytes(), 552);
     /// ```
     pub fn heap_bytes(&self) -> usize {
-        self.states.len() * mem::size_of::<State>() + self.outputs.len() * mem::size_of::<Output>()
+        self.states.len() * mem::size_of::<State>()
+            + self.mapper.heap_bytes()
+            + self.outputs.len() * mem::size_of::<Output>()
     }
 
     /// Serializes the automaton into a given target.
@@ -644,6 +649,7 @@ impl CharwiseDoubleArrayAhoCorasick {
         for state in &self.states {
             wtr.write_all(&state.serialize())?;
         }
+        self.mapper.serialize(&mut wtr)?;
         wtr.write_all(&u32::try_from(self.outputs.len()).unwrap().to_le_bytes())?;
         for output in &self.outputs {
             wtr.write_all(&output.serialize())?;
@@ -669,12 +675,14 @@ impl CharwiseDoubleArrayAhoCorasick {
             mem::size_of::<u32>() * 3
                 + mem::size_of::<u8>()
                 + 16 * self.states.len()
+                + self.mapper.serialized_bytes()
                 + 8 * self.outputs.len(),
         );
         result.extend_from_slice(&u32::try_from(self.states.len()).unwrap().to_le_bytes());
         for state in &self.states {
             result.extend_from_slice(&state.serialize());
         }
+        self.mapper.serialize_into_vec(&mut result);
         result.extend_from_slice(&u32::try_from(self.outputs.len()).unwrap().to_le_bytes());
         for output in &self.outputs {
             result.extend_from_slice(&output.serialize());
@@ -747,6 +755,9 @@ impl CharwiseDoubleArrayAhoCorasick {
             rdr.read_exact(&mut state_array)?;
             states.push(State::deserialize(state_array));
         }
+
+        let mapper = CodeMapper::deserialize_unchecked(&mut rdr)?;
+
         let mut outputs_len_array = [0; 4];
         rdr.read_exact(&mut outputs_len_array)?;
         let outputs_len = u32::from_le_bytes(outputs_len_array) as usize;
@@ -767,6 +778,7 @@ impl CharwiseDoubleArrayAhoCorasick {
 
         Ok(Self {
             states,
+            mapper,
             outputs,
             match_kind,
             num_states,
@@ -823,6 +835,9 @@ impl CharwiseDoubleArrayAhoCorasick {
             states.push(State::deserialize(source[0..16].try_into().unwrap()));
             source = &source[16..];
         }
+
+        let (mapper, mut source) = CodeMapper::deserialize_from_slice_unchecked(source);
+
         let outputs_len = u32::from_le_bytes(source[0..4].try_into().unwrap()) as usize;
         source = &source[4..];
         let mut outputs = Vec::with_capacity(outputs_len);
@@ -838,6 +853,7 @@ impl CharwiseDoubleArrayAhoCorasick {
         (
             Self {
                 states,
+                mapper,
                 outputs,
                 match_kind,
                 num_states,
@@ -851,7 +867,8 @@ impl CharwiseDoubleArrayAhoCorasick {
     /// `state_id` must be smaller than the length of states.
     #[allow(clippy::cast_possible_wrap)]
     #[inline(always)]
-    unsafe fn get_child_index_unchecked(&self, state_id: u32, mapped_c: u32) -> Option<u32> {
+    unsafe fn get_child_index_unchecked(&self, state_id: u32, c: char) -> Option<u32> {
+        let mapped_c = self.mapper.get(c)?;
         if let Some(base) = self.states.get_unchecked(state_id as usize).base() {
             let child_idx = base + mapped_c as i32;
             if child_idx < 0 {
@@ -871,9 +888,9 @@ impl CharwiseDoubleArrayAhoCorasick {
     ///
     /// `state_id` must be smaller than the length of states.
     #[inline(always)]
-    unsafe fn get_next_state_id_unchecked(&self, mut state_id: u32, mapped_c: u32) -> u32 {
+    unsafe fn get_next_state_id_unchecked(&self, mut state_id: u32, c: char) -> u32 {
         loop {
-            if let Some(state_id) = self.get_child_index_unchecked(state_id, mapped_c) {
+            if let Some(state_id) = self.get_child_index_unchecked(state_id, c) {
                 return state_id;
             }
             if state_id == ROOT_STATE_IDX {
@@ -887,9 +904,9 @@ impl CharwiseDoubleArrayAhoCorasick {
     ///
     /// `state_id` must be smaller than the length of states.
     #[inline(always)]
-    unsafe fn get_next_state_id_leftmost_unchecked(&self, mut state_id: u32, mapped_c: u32) -> u32 {
+    unsafe fn get_next_state_id_leftmost_unchecked(&self, mut state_id: u32, c: char) -> u32 {
         loop {
-            if let Some(state_id) = self.get_child_index_unchecked(state_id, mapped_c) {
+            if let Some(state_id) = self.get_child_index_unchecked(state_id, c) {
                 return state_id;
             }
             if state_id == ROOT_STATE_IDX {

--- a/src/charwise/builder.rs
+++ b/src/charwise/builder.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 
-use crate::charwise::{CharwiseDoubleArrayAhoCorasick, MatchKind, State};
+use crate::charwise::{CharwiseDoubleArrayAhoCorasick, CodeMapper, MatchKind, State};
 use crate::errors::{DaachorseError, Result};
 use crate::nfa_builder::NfaBuilder;
 
@@ -13,6 +13,7 @@ type CharwiseNfaBuilder = NfaBuilder<char>;
 /// Builder for [`CharwiseDoubleArrayAhoCorasick`].
 pub struct CharwiseDoubleArrayAhoCorasickBuilder {
     states: Vec<State>,
+    mapper: CodeMapper,
     match_kind: MatchKind,
 }
 
@@ -45,9 +46,10 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
     ///
     /// assert_eq!(None, it.next());
     /// ```
-    pub const fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             states: vec![],
+            mapper: CodeMapper::default(),
             match_kind: MatchKind::Standard,
         }
     }
@@ -155,6 +157,7 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
 
         Ok(CharwiseDoubleArrayAhoCorasick {
             states: self.states,
+            mapper: self.mapper,
             outputs: nfa.outputs,
             match_kind: self.match_kind,
             num_states,
@@ -167,14 +170,24 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
         P: AsRef<str>,
     {
         let mut nfa = CharwiseNfaBuilder::new(self.match_kind);
+        let mut freqs = vec![];
         {
             let mut chars = vec![];
             for (pattern, value) in patvals {
                 chars.clear();
                 pattern.as_ref().chars().for_each(|c| chars.push(c));
                 nfa.add(&chars, value)?;
+
+                for &c in &chars {
+                    let c = usize::try_from(u32::from(c)).unwrap();
+                    if freqs.len() <= c {
+                        freqs.resize(c + 1, 0);
+                    }
+                    freqs[c] += 1;
+                }
             }
         }
+        self.mapper = CodeMapper::new(&freqs);
 
         if nfa.len == 0 {
             return Err(DaachorseError::invalid_argument("patvals.len()", ">=", 1));
@@ -211,7 +224,7 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
 
             mapped.clear();
             for (&label, &child_id) in &s.edges {
-                mapped.push((label as u32, child_id));
+                mapped.push((self.mapper.get(label).unwrap(), child_id));
             }
             mapped.sort_by(|(c1, _), (c2, _)| c1.cmp(c2));
 

--- a/src/charwise/builder.rs
+++ b/src/charwise/builder.rs
@@ -150,7 +150,7 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
         I: IntoIterator<Item = (P, u32)>,
         P: AsRef<str>,
     {
-        let nfa = self.build_original_nfa(patvals)?;
+        let nfa = self.build_original_nfa_and_mapper(patvals)?;
         let num_states = nfa.states.len() - 1; // -1 is for dead state
 
         self.build_double_array(&nfa)?;
@@ -164,7 +164,7 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
         })
     }
 
-    fn build_original_nfa<I, P>(&mut self, patvals: I) -> Result<CharwiseNfaBuilder>
+    fn build_original_nfa_and_mapper<I, P>(&mut self, patvals: I) -> Result<CharwiseNfaBuilder>
     where
         I: IntoIterator<Item = (P, u32)>,
         P: AsRef<str>,

--- a/src/charwise/iter.rs
+++ b/src/charwise/iter.rs
@@ -141,14 +141,10 @@ where
 
         for (pos, c) in self.haystack.by_ref() {
             self.pos = pos;
-            let mapped_c = c as u32;
 
             // self.state_id is always smaller than self.pma.states.len() because
             // self.pma.get_next_state_id_unchecked() ensures to return such a value.
-            self.state_id = unsafe {
-                self.pma
-                    .get_next_state_id_unchecked(self.state_id, mapped_c)
-            };
+            self.state_id = unsafe { self.pma.get_next_state_id_unchecked(self.state_id, c) };
             if let Some(output_pos) = unsafe {
                 self.pma
                     .states
@@ -178,11 +174,9 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         let mut state_id = ROOT_STATE_IDX;
         for (pos, c) in self.haystack.by_ref() {
-            let mapped_c = c as u32;
-
             // self.state_id is always smaller than self.pma.states.len() because
             // self.pma.get_next_state_id_unchecked() ensures to return such a value.
-            state_id = unsafe { self.pma.get_next_state_id_unchecked(state_id, mapped_c) };
+            state_id = unsafe { self.pma.get_next_state_id_unchecked(state_id, c) };
             if let Some(output_pos) = unsafe {
                 self.pma
                     .states
@@ -212,14 +206,9 @@ where
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
         for (pos, c) in self.haystack.by_ref() {
-            let mapped_c = c as u32;
-
             // self.state_id is always smaller than self.pma.states.len() because
             // self.pma.get_next_state_id_unchecked() ensures to return such a value.
-            self.state_id = unsafe {
-                self.pma
-                    .get_next_state_id_unchecked(self.state_id, mapped_c)
-            };
+            self.state_id = unsafe { self.pma.get_next_state_id_unchecked(self.state_id, c) };
             if let Some(output_pos) = unsafe {
                 self.pma
                     .states
@@ -254,14 +243,10 @@ where
         let mut skips = 0;
         for c in unsafe { self.haystack.as_ref().get_unchecked(self.pos..) }.chars() {
             skips += c.len_utf8();
-            let mapped_c = c as u32;
 
             // state_id is always smaller than self.pma.states.len() because
             // self.pma.get_next_state_id_leftmost_unchecked() ensures to return such a value.
-            state_id = unsafe {
-                self.pma
-                    .get_next_state_id_leftmost_unchecked(state_id, mapped_c)
-            };
+            state_id = unsafe { self.pma.get_next_state_id_leftmost_unchecked(state_id, c) };
             if state_id == DEAD_STATE_IDX {
                 debug_assert_ne!(last_output_pos, OUTPUT_POS_INVALID);
                 break;

--- a/src/charwise/mapper.rs
+++ b/src/charwise/mapper.rs
@@ -1,0 +1,95 @@
+#[cfg(feature = "std")]
+use std::io::{self, Read, Write};
+
+use alloc::vec::Vec;
+
+pub const INVALID_CODE: u32 = u32::MAX;
+
+#[derive(Default, Clone, Debug, PartialEq, Eq)]
+pub struct CodeMapper {
+    table: Vec<u32>,
+}
+
+impl CodeMapper {
+    pub fn new(freqs: &[u32]) -> Self {
+        let sorted = {
+            let mut sorted = vec![];
+            for (c, &f) in freqs.iter().enumerate().filter(|(_, &f)| f != 0) {
+                sorted.push((c, f));
+            }
+            // Note: `c1.cmp(c2)` is necessary to uniquely determine the sort result.
+            sorted.sort_unstable_by(|(c1, f1), (c2, f2)| f2.cmp(f1).then_with(|| c1.cmp(c2)));
+            sorted
+        };
+        let mut table = vec![INVALID_CODE; freqs.len()];
+        for (i, &(c, _)) in sorted.iter().enumerate() {
+            table[c] = i.try_into().unwrap();
+        }
+        Self { table }
+    }
+
+    #[inline(always)]
+    pub fn get(&self, c: char) -> Option<u32> {
+        self.table
+            .get(usize::try_from(u32::from(c)).unwrap())
+            .copied()
+            .filter(|&code| code != INVALID_CODE)
+    }
+
+    #[inline]
+    #[allow(dead_code)]
+    pub fn heap_bytes(&self) -> usize {
+        self.table.len() * core::mem::size_of::<u32>()
+    }
+
+    pub fn serialized_bytes(&self) -> usize {
+        core::mem::size_of::<u32>() + self.table.len() * core::mem::size_of::<u32>()
+    }
+
+    #[cfg(feature = "std")]
+    pub fn serialize<W>(&self, mut wtr: W) -> io::Result<()>
+    where
+        W: Write,
+    {
+        wtr.write_all(&u32::try_from(self.table.len()).unwrap().to_le_bytes())?;
+        for &x in &self.table {
+            wtr.write_all(&x.to_le_bytes())?;
+        }
+        Ok(())
+    }
+
+    pub fn serialize_into_vec(&self, result: &mut Vec<u8>) {
+        result.extend_from_slice(&u32::try_from(self.table.len()).unwrap().to_le_bytes());
+        for &x in &self.table {
+            result.extend_from_slice(&x.to_le_bytes());
+        }
+    }
+
+    #[cfg(feature = "std")]
+    pub unsafe fn deserialize_unchecked<R>(mut rdr: R) -> io::Result<Self>
+    where
+        R: Read,
+    {
+        let mut len_array = [0; 4];
+        rdr.read_exact(&mut len_array)?;
+        let len = u32::from_le_bytes(len_array) as usize;
+        let mut table = Vec::with_capacity(len);
+        for _ in 0..len {
+            let mut x = [0; 4];
+            rdr.read_exact(&mut x)?;
+            table.push(u32::from_le_bytes(x));
+        }
+        Ok(Self { table })
+    }
+
+    pub unsafe fn deserialize_from_slice_unchecked(mut source: &[u8]) -> (Self, &[u8]) {
+        let len = u32::from_le_bytes(source[0..4].try_into().unwrap()) as usize;
+        source = &source[4..];
+        let mut table = Vec::with_capacity(len);
+        for _ in 0..len {
+            table.push(u32::from_le_bytes(source[0..4].try_into().unwrap()));
+            source = &source[4..];
+        }
+        (Self { table }, source)
+    }
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,2 +1,3 @@
 mod double_array_structure;
 mod iterator;
+mod mapper;

--- a/src/tests/mapper.rs
+++ b/src/tests/mapper.rs
@@ -1,0 +1,16 @@
+use crate::charwise::mapper::CodeMapper;
+
+#[test]
+fn test_charwise_code_mapper() {
+    let freqs = vec![3, 6, 0, 2, 3, 0, 3];
+    let mapper = CodeMapper::new(&freqs);
+
+    assert_eq!(mapper.get(0 as char), Some(1));
+    assert_eq!(mapper.get(1 as char), Some(0));
+    assert_eq!(mapper.get(2 as char), None);
+    assert_eq!(mapper.get(3 as char), Some(4));
+    assert_eq!(mapper.get(4 as char), Some(2));
+    assert_eq!(mapper.get(5 as char), None);
+    assert_eq!(mapper.get(6 as char), Some(3));
+    assert_eq!(mapper.get(7 as char), None); // out-of-range
+}


### PR DESCRIPTION
This PR added code mapping for CharwiseDaachorse.

The code mapping enables to represent most characters with small integers, resulting in faster construction, as follows.

```
unidic/build/daachorse/charwise                                                                          
                        time:   [1.7010 s 1.7037 s 1.7081 s]
                        change: [-37.270% -37.017% -36.795%] (p = 0.00 < 0.05)
                        Performance has improved.
```

There is no significant difference in matching time and memory efficiency.

```
unidic/find_overlapping/daachorse/charwise                                                                            
                        time:   [6.5671 ms 6.5730 ms 6.5790 ms]
                        change: [-0.3567% +0.4832% +1.1118%] (p = 0.24 > 0.05)
                        No change in performance detected.
```

```
== data/unidic/unidic ==
# old version
daachorse (charwise): 23361332 bytes, 22.279 MiB
# new version
daachorse (charwise): 23413260 bytes, 22.329 MiB
```