### PR TITLE
Change memory layout of state

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 
 use crate::errors::{DaachorseError, Result};
 use crate::nfa_builder::{NfaBuilder, DEAD_STATE_ID, ROOT_STATE_ID, VALUE_INVALID};
-use crate::{DoubleArrayAhoCorasick, MatchKind, State, DEAD_STATE_IDX, FAIL_MAX, ROOT_STATE_IDX};
+use crate::{DoubleArrayAhoCorasick, MatchKind, State, DEAD_STATE_IDX, ROOT_STATE_IDX};
 
 // The maximum value of each double-array block.
 const BLOCK_MAX: u8 = u8::MAX;
@@ -356,9 +356,6 @@ impl DoubleArrayAhoCorasickBuilder {
             } else {
                 let fail_idx = state_id_map[fail_id as usize];
                 debug_assert_ne!(fail_idx, DEAD_STATE_IDX);
-                if fail_idx > FAIL_MAX {
-                    return Err(DaachorseError::automaton_scale("fail_idx", FAIL_MAX));
-                }
                 self.states[idx].set_fail(fail_idx);
             }
         }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,7 +1,7 @@
 use alloc::vec::Vec;
 
 use crate::errors::{DaachorseError, Result};
-use crate::nfa_builder::{NfaBuilder, DEAD_STATE_ID, ROOT_STATE_ID, VALUE_INVALID};
+use crate::nfa_builder::{self, NfaBuilder, DEAD_STATE_ID, ROOT_STATE_ID, VALUE_INVALID};
 use crate::{DoubleArrayAhoCorasick, MatchKind, State, DEAD_STATE_IDX, ROOT_STATE_IDX};
 
 // The maximum value of each double-array block.
@@ -348,7 +348,11 @@ impl DoubleArrayAhoCorasickBuilder {
             debug_assert_ne!(idx, DEAD_STATE_IDX as usize);
 
             let s = &state.borrow();
-            self.states[idx].set_output_pos(s.output_pos);
+            if s.output_pos == nfa_builder::OUTPUT_POS_INVALID {
+                self.states[idx].set_output_pos(crate::OUTPUT_POS_INVALID);
+            } else {
+                self.states[idx].set_output_pos(s.output_pos);
+            }
 
             let fail_id = s.fail;
             if fail_id == DEAD_STATE_ID {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -2,7 +2,9 @@ use alloc::vec::Vec;
 
 use crate::errors::{DaachorseError, Result};
 use crate::nfa_builder::{self, NfaBuilder, DEAD_STATE_ID, ROOT_STATE_ID, VALUE_INVALID};
-use crate::{DoubleArrayAhoCorasick, MatchKind, State, DEAD_STATE_IDX, ROOT_STATE_IDX};
+use crate::{
+    DoubleArrayAhoCorasick, MatchKind, State, DEAD_STATE_IDX, OUTPUT_POS_INVALID, ROOT_STATE_IDX,
+};
 
 // The maximum value of each double-array block.
 const BLOCK_MAX: u8 = u8::MAX;
@@ -288,6 +290,12 @@ impl DoubleArrayAhoCorasickBuilder {
         }
         if nfa.len == 0 {
             return Err(DaachorseError::invalid_argument("patvals.len()", ">=", 1));
+        }
+        if nfa.len > OUTPUT_POS_INVALID as usize {
+            return Err(DaachorseError::automaton_scale(
+                "patvals.len()",
+                OUTPUT_POS_INVALID,
+            ));
         }
         let q = match self.match_kind {
             MatchKind::Standard => nfa.build_fails(),

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -357,9 +357,9 @@ impl DoubleArrayAhoCorasickBuilder {
 
             let s = &state.borrow();
             if s.output_pos == nfa_builder::OUTPUT_POS_INVALID {
-                self.states[idx].set_output_pos(crate::OUTPUT_POS_INVALID);
+                self.states[idx].set_output_pos(crate::OUTPUT_POS_INVALID)?;
             } else {
-                self.states[idx].set_output_pos(s.output_pos);
+                self.states[idx].set_output_pos(s.output_pos)?;
             }
 
             let fail_id = s.fail;

--- a/src/charwise.rs
+++ b/src/charwise.rs
@@ -66,7 +66,7 @@ use crate::{MatchKind, Output};
 // The maximum BASE value used as an invalid value.
 pub(crate) const BASE_INVALID: i32 = i32::MAX;
 // The maximum output position value used as an invalid value.
-pub(crate) const OUTPUT_POS_INVALID: u32 = u32::MAX;
+pub(crate) const OUTPUT_POS_INVALID: u32 = u32::MAX >> 8;
 // The root index position.
 pub(crate) const ROOT_STATE_IDX: u32 = 0;
 // The dead index position.

--- a/src/charwise.rs
+++ b/src/charwise.rs
@@ -66,7 +66,7 @@ use crate::{MatchKind, Output};
 // The maximum BASE value used as an invalid value.
 pub(crate) const BASE_INVALID: i32 = i32::MAX;
 // The maximum output position value used as an invalid value.
-pub(crate) const OUTPUT_POS_INVALID: u32 = u32::MAX >> 8;
+pub(crate) const OUTPUT_POS_INVALID: u32 = u32::MAX;
 // The root index position.
 pub(crate) const ROOT_STATE_IDX: u32 = 0;
 // The dead index position.

--- a/src/charwise/builder.rs
+++ b/src/charwise/builder.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 
 use crate::charwise::{CharwiseDoubleArrayAhoCorasick, CodeMapper, MatchKind, State};
 use crate::errors::{DaachorseError, Result};
-use crate::nfa_builder::NfaBuilder;
+use crate::nfa_builder::{self, NfaBuilder};
 
 use crate::charwise::{DEAD_STATE_IDX, OUTPUT_POS_INVALID, ROOT_STATE_IDX};
 use crate::nfa_builder::{DEAD_STATE_ID, ROOT_STATE_ID, VALUE_INVALID};
@@ -259,7 +259,11 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
             debug_assert_ne!(idx, DEAD_STATE_IDX as usize);
 
             let s = &state.borrow();
-            self.states[idx].set_output_pos(s.output_pos);
+            if s.output_pos == nfa_builder::OUTPUT_POS_INVALID {
+                self.states[idx].set_output_pos(OUTPUT_POS_INVALID);
+            } else {
+                self.states[idx].set_output_pos(s.output_pos);
+            }
 
             let fail_id = s.fail;
             if fail_id == DEAD_STATE_ID {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -386,8 +386,8 @@ impl Match {
 ///
 /// # Limitations
 ///
-/// For memory- and cache-efficiency, a FAIL pointer is represented in 24 bits.
-/// Thus, if a very large pattern set is given,
+/// The maximum number of patterns is limited to 2^24-1.
+/// If a larger number of patterns is given,
 /// [`DaachorseError`](errors::DaachorseError) will be reported.
 pub struct DoubleArrayAhoCorasick {
     states: Vec<State>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,6 +194,7 @@ pub(crate) const DEAD_STATE_IDX: u32 = 1;
 struct State {
     base: u32,
     fail: u32,
+    // 3 bytes for output_pos and 1 byte for check.
     opos_ch: u32,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,7 @@ use core::mem;
 use alloc::vec::Vec;
 
 pub use builder::DoubleArrayAhoCorasickBuilder;
-use errors::Result;
+use errors::{DaachorseError, Result};
 use iter::{
     FindIterator, FindOverlappingIterator, FindOverlappingNoSuffixIterator, LestmostFindIterator,
     U8SliceIterator,
@@ -247,9 +247,17 @@ impl State {
     }
 
     #[inline(always)]
-    pub fn set_output_pos(&mut self, x: u32) {
-        self.opos_ch &= CHECK_MASK;
-        self.opos_ch |= x << 8;
+    pub fn set_output_pos(&mut self, x: u32) -> Result<()> {
+        if x <= OUTPUT_POS_INVALID {
+            self.opos_ch &= CHECK_MASK;
+            self.opos_ch |= x << 8;
+            Ok(())
+        } else {
+            Err(DaachorseError::automaton_scale(
+                "outputs.len()",
+                OUTPUT_POS_INVALID,
+            ))
+        }
     }
 
     #[inline(always)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,11 +183,7 @@ use iter::{
 pub(crate) const BASE_INVALID: u32 = u32::MAX;
 // The maximum output position value used as an invalid value.
 pub(crate) const OUTPUT_POS_INVALID: u32 = u32::MAX >> 8;
-// The maximum FAIL value.
-pub(crate) const FAIL_MAX: u32 = 0xFF_FFFF;
-// The mask value of FAIL for `State::fach`.
-const FAIL_MASK: u32 = FAIL_MAX << 8;
-// The mask value of CEHCK for `State::fach`.
+// The mask value of CEHCK for `State::opos_ch`.
 const CHECK_MASK: u32 = 0xFF;
 // The root index position.
 pub(crate) const ROOT_STATE_IDX: u32 = 0;

--- a/src/nfa_builder.rs
+++ b/src/nfa_builder.rs
@@ -3,7 +3,7 @@ use core::cell::RefCell;
 use alloc::vec::Vec;
 
 use crate::errors::{DaachorseError, Result};
-use crate::{MatchKind, Output, OUTPUT_POS_INVALID};
+use crate::{MatchKind, Output};
 
 // The maximum value of a pattern used as an invalid value.
 pub const VALUE_INVALID: u32 = u32::MAX;
@@ -11,6 +11,8 @@ pub const VALUE_INVALID: u32 = u32::MAX;
 pub const LENGTH_INVALID: u32 = 0;
 // The length used as an invalid value.
 pub const LENGTH_MAX: u32 = u32::MAX >> 1;
+// The maximum output position value used as an invalid value.
+pub const OUTPUT_POS_INVALID: u32 = u32::MAX;
 // The root state id of SparseNFA.
 pub const ROOT_STATE_ID: u32 = 0;
 // The dead state id of SparseNFA.


### PR DESCRIPTION
This PR changes the memory layout of `State` to increase the maximum number of states in the automaton.

The current layout is base = 4 bytes, check = 1 bytes, fail = 3 bytes, outpos = 4 bytes.
This new layout is base = 4 bytes, check = 1 bytes, fail = 4 bytes, outpos = 3 bytes.

The memory usage is unchanged.
There is no significant difference in matching time.
```
unidic/find/daachorse   time:   [2.9390 ms 2.9437 ms 2.9491 ms]                                  
                        change: [-8.5873% -6.9023% -5.5108%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 30 measurements (3.33%)
  1 (3.33%) high severe

unidic/find_overlapping/daachorse                                                                           
                        time:   [18.286 ms 18.448 ms 18.624 ms]
                        change: [-1.0303% +0.1783% +1.3779%] (p = 0.78 > 0.05)
                        No change in performance detected.
Found 1 outliers among 30 measurements (3.33%)
  1 (3.33%) high mild
unidic/find_overlapping/daachorse/no_suffix                                                                           
                        time:   [18.020 ms 18.162 ms 18.304 ms]
                        change: [+0.3086% +1.5027% +2.6825%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 30 measurements (3.33%)
  1 (3.33%) low mild

unidic/leftmost_longest_find/daachorse                                                                           
                        time:   [15.805 ms 15.928 ms 16.059 ms]
                        change: [-0.9695% +0.0749% +1.2078%] (p = 0.90 > 0.05)
                        No change in performance detected.

unidic/leftmost_first_find/daachorse                                                                            
                        time:   [6.0358 ms 6.0451 ms 6.0546 ms]
                        change: [+1.2919% +1.5690% +1.8295%] (p = 0.00 < 0.05)
                        Performance has regressed.

unidic/build/daachorse  time:   [941.91 ms 944.97 ms 948.18 ms]                                 
                        change: [+3.6837% +4.1426% +4.6519%] (p = 0.00 < 0.05)
                        Performance has regressed.

words_100000/find/daachorse                                                                            
                        time:   [6.5562 ms 6.5790 ms 6.6061 ms]
                        change: [-2.3612% -1.7940% -1.2052%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 30 measurements (6.67%)
  2 (6.67%) high mild

words_100000/find_overlapping/daachorse                                                                            
                        time:   [7.5923 ms 7.6164 ms 7.6418 ms]
                        change: [-4.0615% -3.5238% -3.0029%] (p = 0.00 < 0.05)
                        Performance has improved.
words_100000/find_overlapping/daachorse/no_suffix                                                                            
                        time:   [8.0410 ms 8.0697 ms 8.1019 ms]
                        change: [+0.8319% +1.6382% +2.3528%] (p = 0.00 < 0.05)
                        Change within noise threshold.

words_100000/leftmost_longest_find/daachorse                                                                            
                        time:   [8.3553 ms 8.3955 ms 8.4495 ms]
                        change: [-1.8438% -1.2011% -0.4177%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 30 measurements (10.00%)
  1 (3.33%) low mild
  2 (6.67%) high severe

words_100000/leftmost_first_find/daachorse                                                                            
                        time:   [7.8774 ms 7.9015 ms 7.9253 ms]
                        change: [-2.4572% -1.9539% -1.4717%] (p = 0.00 < 0.05)
                        Performance has improved.

words_100000/build/daachorse                                                                          
                        time:   [500.24 ms 501.80 ms 503.43 ms]
                        change: [-1.4000% -1.0285% -0.6386%] (p = 0.00 < 0.05)
                        Change within noise threshold.
```