### PR TITLE
Use `Option<NonZeroU32>` instead of using `OUTPUT_POS_INVALID`

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,9 +1,9 @@
 use alloc::vec::Vec;
 
 use crate::errors::{DaachorseError, Result};
-use crate::nfa_builder::{self, NfaBuilder, DEAD_STATE_ID, ROOT_STATE_ID, VALUE_INVALID};
+use crate::nfa_builder::{NfaBuilder, DEAD_STATE_ID, ROOT_STATE_ID, VALUE_INVALID};
 use crate::{
-    DoubleArrayAhoCorasick, MatchKind, State, DEAD_STATE_IDX, OUTPUT_POS_INVALID, ROOT_STATE_IDX,
+    DoubleArrayAhoCorasick, MatchKind, State, DEAD_STATE_IDX, OUTPUT_POS_MAX, ROOT_STATE_IDX,
 };
 
 // The maximum value of each double-array block.
@@ -291,10 +291,10 @@ impl DoubleArrayAhoCorasickBuilder {
         if nfa.len == 0 {
             return Err(DaachorseError::invalid_argument("patvals.len()", ">=", 1));
         }
-        if nfa.len > OUTPUT_POS_INVALID as usize {
+        if nfa.len > OUTPUT_POS_MAX as usize {
             return Err(DaachorseError::automaton_scale(
                 "patvals.len()",
-                OUTPUT_POS_INVALID,
+                OUTPUT_POS_MAX,
             ));
         }
         let q = match self.match_kind {
@@ -356,11 +356,7 @@ impl DoubleArrayAhoCorasickBuilder {
             debug_assert_ne!(idx, DEAD_STATE_IDX as usize);
 
             let s = &state.borrow();
-            if s.output_pos == nfa_builder::OUTPUT_POS_INVALID {
-                self.states[idx].set_output_pos(crate::OUTPUT_POS_INVALID)?;
-            } else {
-                self.states[idx].set_output_pos(s.output_pos)?;
-            }
+            self.states[idx].set_output_pos(s.output_pos)?;
 
             let fail_id = s.fail;
             if fail_id == DEAD_STATE_ID {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -291,10 +291,10 @@ impl DoubleArrayAhoCorasickBuilder {
         if nfa.len == 0 {
             return Err(DaachorseError::invalid_argument("patvals.len()", ">=", 1));
         }
-        if nfa.len >= OUTPUT_POS_MAX as usize {
+        if nfa.len > OUTPUT_POS_MAX as usize {
             return Err(DaachorseError::automaton_scale(
                 "patvals.len()",
-                OUTPUT_POS_MAX - 1,
+                OUTPUT_POS_MAX,
             ));
         }
         let q = match self.match_kind {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -291,10 +291,10 @@ impl DoubleArrayAhoCorasickBuilder {
         if nfa.len == 0 {
             return Err(DaachorseError::invalid_argument("patvals.len()", ">=", 1));
         }
-        if nfa.len > OUTPUT_POS_MAX as usize {
+        if nfa.len >= OUTPUT_POS_MAX as usize {
             return Err(DaachorseError::automaton_scale(
                 "patvals.len()",
-                OUTPUT_POS_MAX,
+                OUTPUT_POS_MAX - 1,
             ));
         }
         let q = match self.match_kind {

--- a/src/charwise.rs
+++ b/src/charwise.rs
@@ -990,8 +990,7 @@ impl State {
         result[0..4].copy_from_slice(&self.base.to_le_bytes());
         result[4..8].copy_from_slice(&self.check.to_le_bytes());
         result[8..12].copy_from_slice(&self.fail.to_le_bytes());
-        result[12..16]
-            .copy_from_slice(&self.output_pos.map_or(0, NonZeroU32::get).to_le_bytes());
+        result[12..16].copy_from_slice(&self.output_pos.map_or(0, NonZeroU32::get).to_le_bytes());
         result
     }
 

--- a/src/charwise.rs
+++ b/src/charwise.rs
@@ -991,7 +991,7 @@ impl State {
         result[4..8].copy_from_slice(&self.check.to_le_bytes());
         result[8..12].copy_from_slice(&self.fail.to_le_bytes());
         result[12..16]
-            .copy_from_slice(&self.output_pos.map(|x| x.get()).unwrap_or(0).to_le_bytes());
+            .copy_from_slice(&self.output_pos.map_or(0, NonZeroU32::get).to_le_bytes());
         result
     }
 

--- a/src/charwise.rs
+++ b/src/charwise.rs
@@ -610,7 +610,7 @@ impl CharwiseDoubleArrayAhoCorasick {
     /// let patterns = vec!["bcd", "ab", "a"];
     /// let pma = CharwiseDoubleArrayAhoCorasick::new(patterns).unwrap();
     ///
-    /// assert_eq!(pma.heap_bytes(), 552);
+    /// assert_eq!(564, pma.heap_bytes());
     /// ```
     pub fn heap_bytes(&self) -> usize {
         self.states.len() * mem::size_of::<State>()

--- a/src/charwise.rs
+++ b/src/charwise.rs
@@ -65,8 +65,8 @@ use crate::{MatchKind, Output};
 
 // The maximum BASE value used as an invalid value.
 pub(crate) const BASE_INVALID: i32 = i32::MAX;
-// The maximum output position value used as an invalid value.
-pub(crate) const OUTPUT_POS_INVALID: u32 = u32::MAX;
+// an invalid value.
+pub(crate) const OUTPUT_POS_INVALID: u32 = 0;
 // The root index position.
 pub(crate) const ROOT_STATE_IDX: u32 = 0;
 // The dead index position.
@@ -315,7 +315,7 @@ impl CharwiseDoubleArrayAhoCorasick {
             haystack: unsafe { CharWithEndOffsetIterator::new(StrIterator::new(haystack)) },
             state_id: ROOT_STATE_IDX,
             pos: 0,
-            output_pos: OUTPUT_POS_INVALID as usize,
+            output_pos: OUTPUT_POS_INVALID,
         }
     }
 
@@ -373,7 +373,7 @@ impl CharwiseDoubleArrayAhoCorasick {
             haystack: CharWithEndOffsetIterator::new(haystack),
             state_id: ROOT_STATE_IDX,
             pos: 0,
-            output_pos: OUTPUT_POS_INVALID as usize,
+            output_pos: OUTPUT_POS_INVALID,
         }
     }
 

--- a/src/charwise/builder.rs
+++ b/src/charwise/builder.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec;
 
 use crate::charwise::{CharwiseDoubleArrayAhoCorasick, CodeMapper, MatchKind, State};
 use crate::errors::{DaachorseError, Result};
-use crate::nfa_builder::{self, NfaBuilder};
+use crate::nfa_builder::NfaBuilder;
 
 use crate::charwise::{DEAD_STATE_IDX, OUTPUT_POS_INVALID, ROOT_STATE_IDX};
 use crate::nfa_builder::{DEAD_STATE_ID, ROOT_STATE_ID, VALUE_INVALID};
@@ -259,11 +259,7 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
             debug_assert_ne!(idx, DEAD_STATE_IDX as usize);
 
             let s = &state.borrow();
-            if s.output_pos == nfa_builder::OUTPUT_POS_INVALID {
-                self.states[idx].set_output_pos(OUTPUT_POS_INVALID);
-            } else {
-                self.states[idx].set_output_pos(s.output_pos);
-            }
+            self.states[idx].set_output_pos(s.output_pos);
 
             let fail_id = s.fail;
             if fail_id == DEAD_STATE_ID {

--- a/src/charwise/builder.rs
+++ b/src/charwise/builder.rs
@@ -1,10 +1,12 @@
+use core::num::NonZeroU32;
+
 use alloc::vec::Vec;
 
 use crate::charwise::{CharwiseDoubleArrayAhoCorasick, CodeMapper, MatchKind, State};
 use crate::errors::{DaachorseError, Result};
 use crate::nfa_builder::NfaBuilder;
 
-use crate::charwise::{DEAD_STATE_IDX, OUTPUT_POS_INVALID, ROOT_STATE_IDX};
+use crate::charwise::{DEAD_STATE_IDX, ROOT_STATE_IDX};
 use crate::nfa_builder::{DEAD_STATE_ID, ROOT_STATE_ID, VALUE_INVALID};
 
 // Specialized [`NfaBuilder`] handling labels of `char`.
@@ -354,7 +356,10 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
 
     #[inline(always)]
     fn get_prev(&self, i: u32) -> u32 {
-        self.states[i as usize].output_pos().unwrap()
+        self.states[i as usize]
+            .output_pos()
+            .map(|x| x.get())
+            .unwrap_or(0)
     }
 
     #[inline(always)]
@@ -364,7 +369,7 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
 
     #[inline(always)]
     fn set_prev(&mut self, i: u32, x: u32) {
-        self.states[i as usize].set_output_pos(x);
+        self.states[i as usize].set_output_pos(NonZeroU32::new(x));
     }
 
     #[inline(always)]
@@ -376,6 +381,6 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
     fn set_fixed(&mut self, i: u32) {
         debug_assert_ne!(i, DEAD_STATE_IDX);
         self.states[i as usize].set_fail(DEAD_STATE_IDX);
-        self.states[i as usize].set_output_pos(OUTPUT_POS_INVALID);
+        self.states[i as usize].set_output_pos(None);
     }
 }

--- a/src/charwise/builder.rs
+++ b/src/charwise/builder.rs
@@ -356,10 +356,7 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
 
     #[inline(always)]
     fn get_prev(&self, i: u32) -> u32 {
-        self.states[i as usize]
-            .output_pos()
-            .map(|x| x.get())
-            .unwrap_or(0)
+        self.states[i as usize].output_pos().unwrap().get()
     }
 
     #[inline(always)]

--- a/src/charwise/iter.rs
+++ b/src/charwise/iter.rs
@@ -1,10 +1,11 @@
 //! Iterators for [`CharwiseDoubleArrayAhoCorasick`].
 
 use core::iter::Enumerate;
+use core::num::NonZeroU32;
 
 use crate::charwise::CharwiseDoubleArrayAhoCorasick;
 use crate::Match;
-use crate::{DEAD_STATE_IDX, OUTPUT_POS_INVALID, ROOT_STATE_IDX};
+use crate::{DEAD_STATE_IDX, ROOT_STATE_IDX};
 
 /// Iterator for some struct that implements [`AsRef<str>`].
 pub struct StrIterator<P> {
@@ -99,7 +100,7 @@ pub struct FindOverlappingIterator<'a, P> {
     pub(crate) haystack: CharWithEndOffsetIterator<P>,
     pub(crate) state_id: u32,
     pub(crate) pos: usize,
-    pub(crate) output_pos: u32,
+    pub(crate) output_pos: Option<NonZeroU32>,
 }
 
 /// Iterator created by [`CharwiseDoubleArrayAhoCorasick::find_overlapping_iter()`].
@@ -130,15 +131,14 @@ where
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
-        if self.output_pos != OUTPUT_POS_INVALID {
-            if let Some(out) = self.pma.outputs.get(self.output_pos as usize) {
-                self.output_pos = out.parent();
-                return Some(Match {
-                    length: out.length() as usize,
-                    end: self.pos,
-                    value: out.value() as usize,
-                });
-            }
+        if let Some(output_pos) = self.output_pos {
+            let out = unsafe { self.pma.outputs.get_unchecked(output_pos.get() as usize) };
+            self.output_pos = out.parent();
+            return Some(Match {
+                length: out.length() as usize,
+                end: self.pos,
+                value: out.value() as usize,
+            });
         }
 
         for (pos, c) in self.haystack.by_ref() {
@@ -153,7 +153,7 @@ where
                     .get_unchecked(self.state_id as usize)
                     .output_pos()
             } {
-                let out = unsafe { self.pma.outputs.get_unchecked(output_pos as usize) };
+                let out = unsafe { self.pma.outputs.get_unchecked(output_pos.get() as usize) };
                 self.output_pos = out.parent();
                 return Some(Match {
                     length: out.length() as usize,
@@ -187,7 +187,7 @@ where
             } {
                 // output_pos is always smaller than self.pma.outputs.len() because
                 // State::output_pos() ensures to return such a value when it is Some.
-                let out = unsafe { self.pma.outputs.get_unchecked(output_pos as usize) };
+                let out = unsafe { self.pma.outputs.get_unchecked(output_pos.get() as usize) };
                 return Some(Match {
                     length: out.length() as usize,
                     end: pos,
@@ -219,7 +219,7 @@ where
             } {
                 // output_pos is always smaller than self.pma.outputs.len() because
                 // State::output_pos() ensures to return such a value when it is Some.
-                let out = unsafe { self.pma.outputs.get_unchecked(output_pos as usize) };
+                let out = unsafe { self.pma.outputs.get_unchecked(output_pos.get() as usize) };
                 return Some(Match {
                     length: out.length() as usize,
                     end: pos,
@@ -240,7 +240,7 @@ where
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
         let mut state_id = ROOT_STATE_IDX;
-        let mut last_output_pos = OUTPUT_POS_INVALID;
+        let mut last_output_pos = None;
 
         let mut skips = 0;
         for c in unsafe { self.haystack.as_ref().get_unchecked(self.pos..) }.chars() {
@@ -250,7 +250,7 @@ where
             // self.pma.get_next_state_id_leftmost_unchecked() ensures to return such a value.
             state_id = unsafe { self.pma.get_next_state_id_leftmost_unchecked(state_id, c) };
             if state_id == DEAD_STATE_IDX {
-                debug_assert_ne!(last_output_pos, OUTPUT_POS_INVALID);
+                debug_assert_ne!(last_output_pos, None);
                 break;
             }
 
@@ -262,23 +262,21 @@ where
                     .get_unchecked(state_id as usize)
                     .output_pos()
             } {
-                last_output_pos = output_pos;
+                last_output_pos.replace(output_pos);
                 self.pos += skips;
                 skips = 0;
             }
         }
 
-        if last_output_pos == OUTPUT_POS_INVALID {
-            None
-        } else {
+        last_output_pos.map(|output_pos| {
             // last_output_pos is always smaller than self.pma.outputs.len() because
             // State::output_pos() ensures to return such a value when it is Some.
-            let out = unsafe { self.pma.outputs.get_unchecked(last_output_pos as usize) };
-            Some(Match {
+            let out = unsafe { self.pma.outputs.get_unchecked(output_pos.get() as usize) };
+            Match {
                 length: out.length() as usize,
                 end: self.pos,
                 value: out.value() as usize,
-            })
-        }
+            }
+        })
     }
 }

--- a/src/charwise/iter.rs
+++ b/src/charwise/iter.rs
@@ -132,6 +132,8 @@ where
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(output_pos) = self.output_pos {
+            // output_pos.get() is always smaller than self.pma.outputs.len() because
+            // Output::parent() ensures to return such a value when it is Some.
             let out = unsafe { self.pma.outputs.get_unchecked(output_pos.get() as usize) };
             self.output_pos = out.parent();
             return Some(Match {
@@ -153,6 +155,8 @@ where
                     .get_unchecked(self.state_id as usize)
                     .output_pos()
             } {
+                // output_pos.get() is always smaller than self.pma.outputs.len() because
+                // State::output_pos() ensures to return such a value when it is Some.
                 let out = unsafe { self.pma.outputs.get_unchecked(output_pos.get() as usize) };
                 self.output_pos = out.parent();
                 return Some(Match {

--- a/src/charwise/iter.rs
+++ b/src/charwise/iter.rs
@@ -250,7 +250,7 @@ where
             // self.pma.get_next_state_id_leftmost_unchecked() ensures to return such a value.
             state_id = unsafe { self.pma.get_next_state_id_leftmost_unchecked(state_id, c) };
             if state_id == DEAD_STATE_IDX {
-                debug_assert_ne!(last_output_pos, None);
+                debug_assert!(last_output_pos.is_some());
                 break;
             }
 

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -192,7 +192,7 @@ where
             // self.pma.get_next_state_id_leftmost_unchecked() ensures to return such a value.
             state_id = unsafe { self.pma.get_next_state_id_leftmost_unchecked(state_id, c) };
             if state_id == DEAD_STATE_IDX {
-                debug_assert_ne!(last_output_pos, None);
+                debug_assert!(last_output_pos.is_some());
                 break;
             }
 

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -94,6 +94,8 @@ where
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(output_pos) = self.output_pos {
+            // output_pos.get() is always smaller than self.pma.outputs.len() because
+            // Output::parent() ensures to return such a value when it is Some.
             let out = unsafe { self.pma.outputs.get_unchecked(output_pos.get() as usize) };
             self.output_pos = out.parent();
             return Some(Match {
@@ -113,6 +115,8 @@ where
                     .output_pos()
             } {
                 self.pos = pos + 1;
+                // output_pos.get() is always smaller than self.pma.outputs.len() because
+                // State::output_pos() ensures to return such a value when it is Some.
                 let out = unsafe { self.pma.outputs.get_unchecked(output_pos.get() as usize) };
                 self.output_pos = out.parent();
                 return Some(Match {

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,10 +1,11 @@
 //! Iterators for [`DoubleArrayAhoCorasick`].
 
 use core::iter::Enumerate;
+use core::num::NonZeroU32;
 
 use crate::{DoubleArrayAhoCorasick, Match};
 
-use crate::{DEAD_STATE_IDX, OUTPUT_POS_INVALID, ROOT_STATE_IDX};
+use crate::{DEAD_STATE_IDX, ROOT_STATE_IDX};
 
 /// Iterator for some struct that implements [`AsRef<[u8]>`].
 pub struct U8SliceIterator<P> {
@@ -63,7 +64,7 @@ where
             } {
                 // output_pos is always smaller than self.pma.outputs.len() because
                 // State::output_pos() ensures to return such a value when it is Some.
-                let out = unsafe { self.pma.outputs.get_unchecked(output_pos as usize) };
+                let out = unsafe { self.pma.outputs.get_unchecked(output_pos.get() as usize) };
                 return Some(Match {
                     length: out.length() as usize,
                     end: pos + 1,
@@ -81,7 +82,7 @@ pub struct FindOverlappingIterator<'a, P> {
     pub(crate) haystack: Enumerate<P>,
     pub(crate) state_id: u32,
     pub(crate) pos: usize,
-    pub(crate) output_pos: u32,
+    pub(crate) output_pos: Option<NonZeroU32>,
 }
 
 impl<'a, P> Iterator for FindOverlappingIterator<'a, P>
@@ -92,15 +93,14 @@ where
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
-        if self.output_pos != OUTPUT_POS_INVALID {
-            if let Some(out) = self.pma.outputs.get(self.output_pos as usize) {
-                self.output_pos = out.parent();
-                return Some(Match {
-                    length: out.length() as usize,
-                    end: self.pos,
-                    value: out.value() as usize,
-                });
-            }
+        if let Some(output_pos) = self.output_pos {
+            let out = unsafe { self.pma.outputs.get_unchecked(output_pos.get() as usize) };
+            self.output_pos = out.parent();
+            return Some(Match {
+                length: out.length() as usize,
+                end: self.pos,
+                value: out.value() as usize,
+            });
         }
         for (pos, c) in self.haystack.by_ref() {
             // self.state_id is always smaller than self.pma.states.len() because
@@ -113,7 +113,7 @@ where
                     .output_pos()
             } {
                 self.pos = pos + 1;
-                let out = unsafe { self.pma.outputs.get_unchecked(output_pos as usize) };
+                let out = unsafe { self.pma.outputs.get_unchecked(output_pos.get() as usize) };
                 self.output_pos = out.parent();
                 return Some(Match {
                     length: out.length() as usize,
@@ -153,7 +153,7 @@ where
             } {
                 // output_pos is always smaller than self.pma.outputs.len() because
                 // State::output_pos() ensures to return such a value when it is Some.
-                let out = unsafe { self.pma.outputs.get_unchecked(output_pos as usize) };
+                let out = unsafe { self.pma.outputs.get_unchecked(output_pos.get() as usize) };
                 return Some(Match {
                     length: out.length() as usize,
                     end: pos + 1,
@@ -184,7 +184,7 @@ where
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
         let mut state_id = ROOT_STATE_IDX;
-        let mut last_output_pos = OUTPUT_POS_INVALID;
+        let mut last_output_pos = None;
 
         let haystack = self.haystack.as_ref();
         for (pos, &c) in haystack.iter().enumerate().skip(self.pos) {
@@ -192,7 +192,7 @@ where
             // self.pma.get_next_state_id_leftmost_unchecked() ensures to return such a value.
             state_id = unsafe { self.pma.get_next_state_id_leftmost_unchecked(state_id, c) };
             if state_id == DEAD_STATE_IDX {
-                debug_assert_ne!(last_output_pos, OUTPUT_POS_INVALID);
+                debug_assert_ne!(last_output_pos, None);
                 break;
             }
 
@@ -204,22 +204,20 @@ where
                     .get_unchecked(state_id as usize)
                     .output_pos()
             } {
-                last_output_pos = output_pos;
+                last_output_pos.replace(output_pos);
                 self.pos = pos + 1;
             }
         }
 
-        if last_output_pos == OUTPUT_POS_INVALID {
-            None
-        } else {
+        last_output_pos.map(|output_pos| {
             // last_output_pos is always smaller than self.pma.outputs.len() because
             // State::output_pos() ensures to return such a value when it is Some.
-            let out = unsafe { self.pma.outputs.get_unchecked(last_output_pos as usize) };
-            Some(Match {
+            let out = unsafe { self.pma.outputs.get_unchecked(output_pos.get() as usize) };
+            Match {
                 length: out.length() as usize,
                 end: self.pos,
                 value: out.value() as usize,
-            })
-        }
+            }
+        })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -877,7 +877,7 @@ impl DoubleArrayAhoCorasick {
     /// let patterns = vec!["bcd", "ab", "a"];
     /// let pma = DoubleArrayAhoCorasick::new(patterns).unwrap();
     ///
-    /// assert_eq!(pma.heap_bytes(), 3108);
+    /// assert_eq!(3120, pma.heap_bytes());
     /// ```
     pub fn heap_bytes(&self) -> usize {
         self.states.len() * mem::size_of::<State>() + self.outputs.len() * mem::size_of::<Output>()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,12 +165,13 @@ mod nfa_builder;
 #[cfg(test)]
 mod tests;
 
-#[cfg(feature = "std")]
-use std::io::{self, Read, Write};
-
 use core::mem;
+use core::num::NonZeroU32;
 
 use alloc::vec::Vec;
+
+#[cfg(feature = "std")]
+use std::io::{self, Read, Write};
 
 pub use builder::DoubleArrayAhoCorasickBuilder;
 use errors::{DaachorseError, Result};
@@ -181,8 +182,6 @@ use iter::{
 
 // The maximum BASE value used as an invalid value.
 pub(crate) const BASE_INVALID: u32 = u32::MAX;
-// an invalid value.
-pub(crate) const OUTPUT_POS_INVALID: u32 = 0;
 // The maximum output position value.
 pub(crate) const OUTPUT_POS_MAX: u32 = u32::MAX >> 8;
 // The mask value of CEHCK for `State::opos_ch`.
@@ -205,7 +204,7 @@ impl Default for State {
         Self {
             base: BASE_INVALID,
             fail: 0,
-            opos_ch: OUTPUT_POS_INVALID << 8,
+            opos_ch: 0,
         }
     }
 }
@@ -228,8 +227,8 @@ impl State {
     }
 
     #[inline(always)]
-    pub fn output_pos(&self) -> Option<u32> {
-        Some(self.opos_ch >> 8).filter(|&x| x != OUTPUT_POS_INVALID)
+    pub const fn output_pos(&self) -> Option<NonZeroU32> {
+        NonZeroU32::new(self.opos_ch >> 8)
     }
 
     #[inline(always)]
@@ -249,7 +248,8 @@ impl State {
     }
 
     #[inline(always)]
-    pub fn set_output_pos(&mut self, x: u32) -> Result<()> {
+    pub fn set_output_pos(&mut self, x: Option<NonZeroU32>) -> Result<()> {
+        let x = x.map(|x| x.get()).unwrap_or(0);
         if x <= OUTPUT_POS_MAX {
             self.opos_ch &= CHECK_MASK;
             self.opos_ch |= x << 8;
@@ -296,12 +296,12 @@ impl core::fmt::Debug for State {
 struct Output {
     value: u32,
     length: u32,
-    parent: u32,
+    parent: Option<NonZeroU32>,
 }
 
 impl Output {
     #[inline(always)]
-    pub const fn new(value: u32, length: u32, parent: u32) -> Self {
+    pub const fn new(value: u32, length: u32, parent: Option<NonZeroU32>) -> Self {
         Self {
             value,
             length,
@@ -320,7 +320,7 @@ impl Output {
     }
 
     #[inline(always)]
-    pub const fn parent(self) -> u32 {
+    pub const fn parent(self) -> Option<NonZeroU32> {
         self.parent
     }
 
@@ -329,7 +329,7 @@ impl Output {
         let mut result = [0; 12];
         result[0..4].copy_from_slice(&self.value.to_le_bytes());
         result[4..8].copy_from_slice(&self.length.to_le_bytes());
-        result[8..12].copy_from_slice(&self.parent.to_le_bytes());
+        result[8..12].copy_from_slice(&self.parent.map(|x| x.get()).unwrap_or(0).to_le_bytes());
         result
     }
 
@@ -338,7 +338,7 @@ impl Output {
         Self {
             value: u32::from_le_bytes(input[0..4].try_into().unwrap()),
             length: u32::from_le_bytes(input[4..8].try_into().unwrap()),
-            parent: u32::from_le_bytes(input[8..12].try_into().unwrap()),
+            parent: NonZeroU32::new(u32::from_le_bytes(input[8..12].try_into().unwrap())),
         }
     }
 }
@@ -628,7 +628,7 @@ impl DoubleArrayAhoCorasick {
             pma: self,
             haystack: U8SliceIterator::new(haystack).enumerate(),
             state_id: ROOT_STATE_IDX,
-            output_pos: OUTPUT_POS_INVALID,
+            output_pos: None,
             pos: 0,
         }
     }
@@ -679,7 +679,7 @@ impl DoubleArrayAhoCorasick {
             pma: self,
             haystack: haystack.enumerate(),
             state_id: ROOT_STATE_IDX,
-            output_pos: OUTPUT_POS_INVALID,
+            output_pos: None,
             pos: 0,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,7 +256,7 @@ impl State {
             Ok(())
         } else {
             Err(DaachorseError::automaton_scale(
-                "outputs.len()",
+                "output_pos",
                 OUTPUT_POS_MAX,
             ))
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,7 +249,7 @@ impl State {
 
     #[inline(always)]
     pub fn set_output_pos(&mut self, x: Option<NonZeroU32>) -> Result<()> {
-        let x = x.map(|x| x.get()).unwrap_or(0);
+        let x = x.map_or(0, NonZeroU32::get);
         if x <= OUTPUT_POS_MAX {
             self.opos_ch &= CHECK_MASK;
             self.opos_ch |= x << 8;
@@ -329,7 +329,7 @@ impl Output {
         let mut result = [0; 12];
         result[0..4].copy_from_slice(&self.value.to_le_bytes());
         result[4..8].copy_from_slice(&self.length.to_le_bytes());
-        result[8..12].copy_from_slice(&self.parent.map(|x| x.get()).unwrap_or(0).to_le_bytes());
+        result[8..12].copy_from_slice(&self.parent.map_or(0, NonZeroU32::get).to_le_bytes());
         result
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,8 +181,10 @@ use iter::{
 
 // The maximum BASE value used as an invalid value.
 pub(crate) const BASE_INVALID: u32 = u32::MAX;
-// The maximum output position value used as an invalid value.
-pub(crate) const OUTPUT_POS_INVALID: u32 = u32::MAX >> 8;
+// an invalid value.
+pub(crate) const OUTPUT_POS_INVALID: u32 = 0;
+// The maximum output position value.
+pub(crate) const OUTPUT_POS_MAX: u32 = u32::MAX >> 8;
 // The mask value of CEHCK for `State::opos_ch`.
 const CHECK_MASK: u32 = 0xFF;
 // The root index position.
@@ -248,14 +250,14 @@ impl State {
 
     #[inline(always)]
     pub fn set_output_pos(&mut self, x: u32) -> Result<()> {
-        if x <= OUTPUT_POS_INVALID {
+        if x <= OUTPUT_POS_MAX {
             self.opos_ch &= CHECK_MASK;
             self.opos_ch |= x << 8;
             Ok(())
         } else {
             Err(DaachorseError::automaton_scale(
                 "outputs.len()",
-                OUTPUT_POS_INVALID,
+                OUTPUT_POS_MAX,
             ))
         }
     }
@@ -626,7 +628,7 @@ impl DoubleArrayAhoCorasick {
             pma: self,
             haystack: U8SliceIterator::new(haystack).enumerate(),
             state_id: ROOT_STATE_IDX,
-            output_pos: OUTPUT_POS_INVALID as usize,
+            output_pos: OUTPUT_POS_INVALID,
             pos: 0,
         }
     }
@@ -677,7 +679,7 @@ impl DoubleArrayAhoCorasick {
             pma: self,
             haystack: haystack.enumerate(),
             state_id: ROOT_STATE_IDX,
-            output_pos: OUTPUT_POS_INVALID as usize,
+            output_pos: OUTPUT_POS_INVALID,
             pos: 0,
         }
     }

--- a/src/nfa_builder.rs
+++ b/src/nfa_builder.rs
@@ -1,4 +1,5 @@
 use core::cell::RefCell;
+use core::num::NonZeroU32;
 
 use alloc::vec::Vec;
 
@@ -11,8 +12,6 @@ pub const VALUE_INVALID: u32 = u32::MAX;
 pub const LENGTH_INVALID: u32 = 0;
 // The length used as an invalid value.
 pub const LENGTH_MAX: u32 = u32::MAX >> 1;
-// The maximum output position value used as an invalid value.
-pub const OUTPUT_POS_INVALID: u32 = 0;
 // The root state id of SparseNFA.
 pub const ROOT_STATE_ID: u32 = 0;
 // The dead state id of SparseNFA.
@@ -43,7 +42,7 @@ pub struct NfaBuilderState<L> {
     pub(crate) edges: EdgeMap<L>,
     pub(crate) fail: u32,
     pub(crate) output: (u32, u32),
-    pub(crate) output_pos: u32,
+    pub(crate) output_pos: Option<NonZeroU32>,
 }
 
 impl<L> Default for NfaBuilderState<L> {
@@ -52,7 +51,7 @@ impl<L> Default for NfaBuilderState<L> {
             edges: EdgeMap::<L>::default(),
             fail: ROOT_STATE_ID,
             output: (VALUE_INVALID, LENGTH_INVALID),
-            output_pos: OUTPUT_POS_INVALID,
+            output_pos: None,
         }
     }
 }
@@ -232,7 +231,7 @@ where
         debug_assert_ne!(q[0], ROOT_STATE_ID);
 
         // Adds a dummy output so that the output_pos is positive.
-        self.outputs.push(Output::new(0, 0, OUTPUT_POS_INVALID));
+        self.outputs.push(Output::new(0, 0, None));
 
         for &state_id in q {
             let s = &mut self.states[state_id as usize].borrow_mut();
@@ -241,13 +240,11 @@ where
                 continue;
             }
 
-            s.output_pos = self.outputs.len().try_into().unwrap();
+            s.output_pos = NonZeroU32::new(self.outputs.len().try_into().unwrap());
             let parent = self.states[s.fail as usize].borrow().output_pos;
 
             self.outputs
                 .push(Output::new(s.output.0, s.output.1, parent));
-            // TODO: wrong!
-            //Self::check_outputs_error(&self.outputs)?;
         }
 
         Ok(())

--- a/src/nfa_builder.rs
+++ b/src/nfa_builder.rs
@@ -231,6 +231,9 @@ where
         // But, there is no problem since Daachorse does not allow an empty pattern.
         debug_assert_ne!(q[0], ROOT_STATE_ID);
 
+        // Adds a dummy output so that the output_pos is positive.
+        self.outputs.push(Output::new(0, 0, OUTPUT_POS_INVALID));
+
         for &state_id in q {
             let s = &mut self.states[state_id as usize].borrow_mut();
             if s.output.0 == VALUE_INVALID {

--- a/src/nfa_builder.rs
+++ b/src/nfa_builder.rs
@@ -12,7 +12,7 @@ pub const LENGTH_INVALID: u32 = 0;
 // The length used as an invalid value.
 pub const LENGTH_MAX: u32 = u32::MAX >> 1;
 // The maximum output position value used as an invalid value.
-pub const OUTPUT_POS_INVALID: u32 = u32::MAX;
+pub const OUTPUT_POS_INVALID: u32 = 0;
 // The root state id of SparseNFA.
 pub const ROOT_STATE_ID: u32 = 0;
 // The dead state id of SparseNFA.
@@ -246,23 +246,11 @@ where
 
             self.outputs
                 .push(Output::new(s.output.0, s.output.1, parent));
-            Self::check_outputs_error(&self.outputs)?;
+            // TODO: wrong!
+            //Self::check_outputs_error(&self.outputs)?;
         }
 
         Ok(())
-    }
-
-    #[inline(always)]
-    #[allow(clippy::missing_const_for_fn)]
-    fn check_outputs_error(outputs: &[Output]) -> Result<()> {
-        if outputs.len() > OUTPUT_POS_INVALID as usize {
-            Err(DaachorseError::automaton_scale(
-                "outputs.len()",
-                OUTPUT_POS_INVALID,
-            ))
-        } else {
-            Ok(())
-        }
     }
 
     #[inline(always)]


### PR DESCRIPTION
This branch uses `Option<NonZeroU32>` for representing `output_pos`.

Currently, the maximum value is used for the invalid value of `output_pos`, but the maximum value of `output_pos` differs between the bytewise DA and the charwise DA.
This change uses `Option<NonZeroU32>` in both DAs to simplify the representation.