### PR TITLE
Use bitwise-XOR instead of PLUS in charwise daachorse

### DIFF
--- a/src/charwise.rs
+++ b/src/charwise.rs
@@ -877,7 +877,7 @@ impl CharwiseDoubleArrayAhoCorasick {
         // child_idx is always smaller than states.len() because
         //  - states.len() is a multiple of (1 << k),
         //    where k is the number of bits needed to represent mapped_c.
-        //  - base() returns smaller than states.len() when it is Some.
+        //  - base() is always smaller than states.len() when it is Some.
         let child_idx = base ^ mapped_c;
         if self.states.get_unchecked(child_idx as usize).check() == state_id {
             Some(child_idx as u32)

--- a/src/charwise.rs
+++ b/src/charwise.rs
@@ -874,9 +874,13 @@ impl CharwiseDoubleArrayAhoCorasick {
     unsafe fn get_child_index_unchecked(&self, state_id: u32, c: char) -> Option<u32> {
         let mapped_c = self.mapper.get(c)?;
         let base = self.states.get_unchecked(state_id as usize).base()?;
-        let child_id = base ^ mapped_c;
-        if self.states.get_unchecked(child_id as usize).check() == state_id {
-            Some(child_id as u32)
+        // child_idx is always smaller than states.len() because
+        //  - states.len() is a multiple of (1 << k),
+        //    where k is the number of bits needed to represent mapped_c.
+        //  - base() returns smaller than states.len() when it is Some.
+        let child_idx = base ^ mapped_c;
+        if self.states.get_unchecked(child_idx as usize).check() == state_id {
+            Some(child_idx as u32)
         } else {
             None
         }

--- a/src/charwise/builder.rs
+++ b/src/charwise/builder.rs
@@ -386,8 +386,3 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
         self.states[i as usize].set_output_pos(None);
     }
 }
-
-const fn get_block_shift(alphabet_size: u32) -> u32 {
-    let max_code = alphabet_size - 1;
-    32 - max_code.leading_zeros()
-}

--- a/src/charwise/builder.rs
+++ b/src/charwise/builder.rs
@@ -274,8 +274,7 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
     }
 
     fn init_array(&mut self) {
-        let block_shift = get_block_shift(self.mapper.alphabet_size()).max(1);
-        self.block_len = 1 << block_shift;
+        self.block_len = self.mapper.alphabet_size().next_power_of_two().max(2);
 
         self.states
             .resize(self.block_len as usize, State::default());

--- a/src/charwise/builder.rs
+++ b/src/charwise/builder.rs
@@ -297,6 +297,7 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
 
     #[inline(always)]
     fn fix_state(&mut self, idx: u32) {
+        // DEAD_STATE_IDX-th element should be always free.
         debug_assert_ne!(idx, DEAD_STATE_IDX);
         debug_assert!(!self.is_fixed(idx));
 
@@ -337,7 +338,7 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
 
     #[inline(always)]
     fn extend_array(&mut self) {
-        let old_len = self.states.len() as u32;
+        let old_len = u32::try_from(self.states.len()).unwrap();
         let new_len = old_len + self.block_len;
 
         for i in old_len..new_len {
@@ -346,7 +347,7 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
             self.set_prev(i, i - 1);
         }
 
-        let head_idx = self.get_next(DEAD_STATE_IDX);
+        let head_idx = DEAD_STATE_IDX;
         let tail_idx = self.get_prev(head_idx);
         self.set_prev(old_len, tail_idx);
         self.set_next(tail_idx, old_len);

--- a/src/charwise/builder.rs
+++ b/src/charwise/builder.rs
@@ -17,6 +17,7 @@ pub struct CharwiseDoubleArrayAhoCorasickBuilder {
     states: Vec<State>,
     mapper: CodeMapper,
     match_kind: MatchKind,
+    block_len: u32,
 }
 
 impl Default for CharwiseDoubleArrayAhoCorasickBuilder {
@@ -53,6 +54,7 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
             states: vec![],
             mapper: CodeMapper::default(),
             match_kind: MatchKind::Standard,
+            block_len: 0,
         }
     }
 
@@ -231,20 +233,14 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
             mapped.sort_by(|(c1, _), (c2, _)| c1.cmp(c2));
 
             let base = self.find_base(&mapped);
-            let max_idx = base + i32::try_from(mapped.last().unwrap().0).unwrap();
-
-            let max_idx = u32::try_from(max_idx).unwrap();
-            if self.states.len() <= max_idx as usize {
-                self.extend_array(max_idx);
+            if self.states.len() <= base as usize {
+                self.extend_array();
             }
 
             for &(c, child_id) in &mapped {
-                let child_idx = base + i32::try_from(c).unwrap();
-
-                let child_idx = u32::try_from(child_idx).unwrap();
+                let child_idx = base ^ c;
                 self.fix_state(child_idx);
                 self.states[child_idx as usize].set_check(state_idx);
-
                 state_id_map[child_id as usize] = child_idx;
                 stack.push(child_id);
             }
@@ -278,10 +274,25 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
     }
 
     fn init_array(&mut self) {
-        self.states.resize(2, State::default());
-        self.set_next(DEAD_STATE_IDX, DEAD_STATE_IDX);
-        self.set_prev(DEAD_STATE_IDX, DEAD_STATE_IDX);
-        self.set_fixed(ROOT_STATE_IDX);
+        let block_shift = get_block_shift(self.mapper.alphabet_size()).max(1);
+        self.block_len = 1 << block_shift;
+
+        self.states
+            .resize(self.block_len as usize, State::default());
+
+        for i in 0..self.block_len {
+            if i == 0 {
+                self.set_prev(i, self.block_len - 1);
+            } else {
+                self.set_prev(i, i - 1);
+            }
+            if i == self.block_len - 1 {
+                self.set_next(i, 0);
+            } else {
+                self.set_next(i, i + 1);
+            }
+        }
+        self.fix_state(ROOT_STATE_IDX);
     }
 
     #[inline(always)]
@@ -298,29 +309,25 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
 
     // edges = [(char, next_id)] sorted by char
     #[inline(always)]
-    fn find_base(&self, edges: &[(u32, u32)]) -> i32 {
+    fn find_base(&self, edges: &[(u32, u32)]) -> u32 {
         debug_assert!(!edges.is_empty());
 
         let mut idx = self.get_next(DEAD_STATE_IDX);
         while idx != DEAD_STATE_IDX {
             debug_assert!(!self.is_fixed(idx));
-            let base = i32::try_from(idx).unwrap() - i32::try_from(edges[0].0).unwrap();
+            let base = idx ^ edges[0].0;
             if self.verify_base(base, edges) {
                 return base;
             }
             idx = self.get_next(idx);
         }
-        i32::try_from(self.states.len()).unwrap() - i32::try_from(edges[0].0).unwrap()
+        u32::try_from(self.states.len()).unwrap() ^ edges[0].0
     }
 
     #[inline(always)]
-    fn verify_base(&self, base: i32, edges: &[(u32, u32)]) -> bool {
+    fn verify_base(&self, base: u32, edges: &[(u32, u32)]) -> bool {
         for &(c, _) in edges {
-            let idx = base + i32::try_from(c).unwrap();
-            let idx = u32::try_from(idx).unwrap();
-            if self.states.len() <= idx as usize {
-                return true;
-            }
+            let idx = base ^ c;
             if self.is_fixed(idx) {
                 return false;
             }
@@ -329,24 +336,22 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
     }
 
     #[inline(always)]
-    fn extend_array(&mut self, max_idx: u32) {
-        while self.states.len() <= max_idx as usize {
-            self.push_state();
+    fn extend_array(&mut self) {
+        let old_len = self.states.len() as u32;
+        let new_len = old_len + self.block_len;
+
+        for i in old_len..new_len {
+            self.states.push(State::default());
+            self.set_next(i, i + 1);
+            self.set_prev(i, i - 1);
         }
-    }
 
-    #[inline(always)]
-    fn push_state(&mut self) {
-        let head_idx = DEAD_STATE_IDX;
+        let head_idx = self.get_next(DEAD_STATE_IDX);
         let tail_idx = self.get_prev(head_idx);
-
-        let new_idx = u32::try_from(self.states.len()).unwrap();
-        self.states.push(State::default());
-
-        self.set_next(new_idx, head_idx);
-        self.set_prev(head_idx, new_idx);
-        self.set_prev(new_idx, tail_idx);
-        self.set_next(tail_idx, new_idx);
+        self.set_prev(old_len, tail_idx);
+        self.set_next(tail_idx, old_len);
+        self.set_next(new_len - 1, head_idx);
+        self.set_prev(head_idx, new_len - 1);
     }
 
     #[inline(always)]
@@ -380,4 +385,9 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
         self.states[i as usize].set_fail(DEAD_STATE_IDX);
         self.states[i as usize].set_output_pos(None);
     }
+}
+
+const fn get_block_shift(alphabet_size: u32) -> u32 {
+    let max_code = alphabet_size - 1;
+    32 - max_code.leading_zeros()
 }


### PR DESCRIPTION
This PR modified to use bitwise-xor operations in transition lookups in charwise daachorse, as well as bytewise daachorse.

This modification allows to remove
 - casting `u32 <=> i32` because `State::base` is implemented with `u32`, and
 - range check in `get_child_index_unchecked`.

The construction time on Unidic was improved by 10%:

```
unidic/build/daachorse/charwise                                                                          
                        time:   [2.9806 s 2.9934 s 3.0077 s]
                        change: [-11.141% -10.495% -9.8434%] (p = 0.00 < 0.05)
                        Performance has improved.
```

There is no significant difference in memory efficiency:

```
== data/unidic/unidic ==
[OLD]
daachorse (charwise): 23413272 bytes, 22.329 MiB
[NEW]
daachorse (charwise): 23465576 bytes, 22.379 MiB
```