### PR TITLE
Move to root state when char is not registered

### DIFF
--- a/src/charwise.rs
+++ b/src/charwise.rs
@@ -890,8 +890,8 @@ impl CharwiseDoubleArrayAhoCorasick {
     /// `state_id` must be smaller than the length of states.
     #[inline(always)]
     unsafe fn get_next_state_id_unchecked(&self, mut state_id: u32, c: char) -> u32 {
-        loop {
-            if let Some(mapped_c) = self.mapper.get(c) {
+        if let Some(mapped_c) = self.mapper.get(c) {
+            loop {
                 if let Some(state_id) = self.get_child_index_unchecked(state_id, mapped_c) {
                     return state_id;
                 }
@@ -899,9 +899,9 @@ impl CharwiseDoubleArrayAhoCorasick {
                     return ROOT_STATE_IDX;
                 }
                 state_id = self.states.get_unchecked(state_id as usize).fail();
-            } else {
-                return ROOT_STATE_IDX;
             }
+        } else {
+            ROOT_STATE_IDX
         }
     }
 


### PR DESCRIPTION
This branch improves fail transitions of the charwise daac.

In the charwise daac, `get_next_state_id_unchecked()` can return the root state immediately when the character is not found in the character map.

This change is effective in sparse situations such as words_100000 bench.
```
unidic/find_overlapping/daachorse/charwise
                        time:   [6.5667 ms 6.5872 ms 6.6170 ms]
                        change: [-3.1561% -2.6908% -2.1607%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 30 measurements (6.67%)
  2 (6.67%) high severe
unidic/find_overlapping/daachorse/charwise/no_suffix
                        time:   [5.7978 ms 5.8123 ms 5.8324 ms]
                        change: [-3.8307% -3.0936% -2.5559%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 30 measurements (3.33%)
  1 (3.33%) high severe

words_100000/find_overlapping/daachorse/charwise
                        time:   [2.5548 ms 2.5564 ms 2.5580 ms]
                        change: [-24.856% -24.706% -24.565%] (p = 0.00 < 0.05)
                        Performance has improved.
words_100000/find_overlapping/daachorse/charwise/no_suffix
                        time:   [2.5439 ms 2.5471 ms 2.5519 ms]
                        change: [-23.731% -23.182% -22.794%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 30 measurements (3.33%)
  1 (3.33%) high severe
```