### PR TITLE
Share ROOT_STATE_IDX and DEAD_STATE_IDX

### DIFF
--- a/src/charwise.rs
+++ b/src/charwise.rs
@@ -910,20 +910,22 @@ impl CharwiseDoubleArrayAhoCorasick {
     /// `state_id` must be smaller than the length of states.
     #[inline(always)]
     unsafe fn get_next_state_id_leftmost_unchecked(&self, mut state_id: u32, c: char) -> u32 {
-        loop {
-            if let Some(mapped_c) = self.mapper.get(c) {
+        if let Some(mapped_c) = self.mapper.get(c) {
+            loop {
                 if let Some(state_id) = self.get_child_index_unchecked(state_id, mapped_c) {
                     return state_id;
                 }
+                if state_id == ROOT_STATE_IDX {
+                    return ROOT_STATE_IDX;
+                }
+                let fail_id = self.states.get_unchecked(state_id as usize).fail();
+                if fail_id == DEAD_STATE_IDX {
+                    return ROOT_STATE_IDX;
+                }
+                state_id = fail_id;
             }
-            if state_id == ROOT_STATE_IDX {
-                return ROOT_STATE_IDX;
-            }
-            let fail_id = self.states.get_unchecked(state_id as usize).fail();
-            if fail_id == DEAD_STATE_IDX {
-                return DEAD_STATE_IDX;
-            }
-            state_id = fail_id;
+        } else {
+            ROOT_STATE_IDX
         }
     }
 }

--- a/src/charwise/iter.rs
+++ b/src/charwise/iter.rs
@@ -5,7 +5,7 @@ use core::num::NonZeroU32;
 
 use crate::charwise::CharwiseDoubleArrayAhoCorasick;
 use crate::Match;
-use crate::{DEAD_STATE_IDX, ROOT_STATE_IDX};
+use crate::ROOT_STATE_IDX;
 
 /// Iterator for some struct that implements [`AsRef<str>`].
 pub struct StrIterator<P> {
@@ -244,7 +244,7 @@ where
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
         let mut state_id = ROOT_STATE_IDX;
-        let mut last_output_pos = None;
+        let mut last_output_pos: Option<NonZeroU32> = None;
 
         let mut skips = 0;
         for c in unsafe { self.haystack.as_ref().get_unchecked(self.pos..) }.chars() {
@@ -253,9 +253,17 @@ where
             // state_id is always smaller than self.pma.states.len() because
             // self.pma.get_next_state_id_leftmost_unchecked() ensures to return such a value.
             state_id = unsafe { self.pma.get_next_state_id_leftmost_unchecked(state_id, c) };
-            if state_id == DEAD_STATE_IDX {
-                debug_assert!(last_output_pos.is_some());
-                break;
+            if state_id == ROOT_STATE_IDX {
+                if let Some(output_pos) = last_output_pos {
+                    // last_output_pos is always smaller than self.pma.outputs.len() because
+                    // State::output_pos() ensures to return such a value when it is Some.
+                    let out = unsafe { self.pma.outputs.get_unchecked(output_pos.get() as usize) };
+                    return Some(Match {
+                        length: out.length() as usize,
+                        end: self.pos,
+                        value: out.value() as usize,
+                    });
+                }
             }
 
             // state_id is always smaller than self.pma.states.len() because


### PR DESCRIPTION
This change improves fail transitions of the leftmost search in charwise daac.

Currently, the iterator returns the pattern stored in `last_output_pos` when the fail is `DEAD_STATE_ID`.
However, this behavior is inefficient because the automaton has to check the fail transition even if the input character is not registered in the automaton.

This branch changes `get_next_state_id_leftmost_unchecked()` to return `ROOT_STATE_IDX` instead of `DEAD_STATE_IDX` and checks `last_output_pos` if the state is `ROOT_STATE_IDX`.
By this change, `get_next_state_id_leftmost_unchecked()` becomes able to return a value immediately if the character is not registered.

```
unidic/leftmost_longest_find/daachorse/charwise
                        time:   [5.0194 ms 5.0457 ms 5.0872 ms]
                        change: [-4.8903% -4.1515% -3.2221%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 30 measurements (6.67%)
  2 (6.67%) high severe

unidic/leftmost_first_find/daachorse/charwise
                        time:   [2.2488 ms 2.2500 ms 2.2514 ms]
                        change: [-0.1346% -0.0531% +0.0225%] (p = 0.21 > 0.05)
                        No change in performance detected.
Found 1 outliers among 30 measurements (3.33%)
  1 (3.33%) high mild

words_100000/leftmost_longest_find/daachorse/charwise
                        time:   [2.7939 ms 2.7994 ms 2.8081 ms]
                        change: [-18.966% -18.767% -18.487%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 30 measurements (10.00%)
  2 (6.67%) high mild
  1 (3.33%) high severe

words_100000/leftmost_first_find/daachorse/charwise
                        time:   [2.6975 ms 2.6998 ms 2.7022 ms]
                        change: [-16.482% -16.189% -15.923%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 30 measurements (3.33%)
  1 (3.33%) high mild
```