### PR TITLE
Generalize the auxiliary data structure in double-array construction

### DIFF
--- a/src/build_helper.rs
+++ b/src/build_helper.rs
@@ -42,8 +42,7 @@ impl BuildHelper {
     /// Gets the index range of elements in the active blocks.
     #[inline(always)]
     pub fn active_index_range(&self) -> Range<u32> {
-        let start = self.capacity().max(self.num_elements()) - self.capacity();
-        start..self.num_elements()
+        self.num_elements().saturating_sub(self.capacity())..self.num_elements()
     }
 
     /// Gets the block index range in the active blocks.
@@ -67,12 +66,7 @@ impl BuildHelper {
     pub fn unused_base_in_block(&self, block_idx: u32) -> Option<u32> {
         let start = block_idx * self.block_len;
         let end = start + self.block_len;
-        for base in start..end {
-            if !self.is_used_base(base) {
-                return Some(base);
-            }
-        }
-        None
+        (start..end).find(|&base| !self.is_used_base(base))
     }
 
     /// Checks if the BASE value is used.
@@ -155,11 +149,7 @@ impl BuildHelper {
     /// Retruns the index of an active block that will be dropped in the next `push_block`.
     #[inline(always)]
     pub fn dropped_block(&self) -> Option<u32> {
-        if self.capacity() <= self.num_elements() {
-            Some(self.active_block_range().start)
-        } else {
-            None
-        }
+        (self.capacity() <= self.num_elements()).then(|| self.active_block_range().start)
     }
 
     #[inline(always)]

--- a/src/build_helper.rs
+++ b/src/build_helper.rs
@@ -35,7 +35,7 @@ impl BuildHelper {
 
     /// Gets the number of current double-array elements.
     #[inline(always)]
-    pub fn num_elements(&self) -> u32 {
+    pub const fn num_elements(&self) -> u32 {
         self.num_elements
     }
 

--- a/src/build_helper.rs
+++ b/src/build_helper.rs
@@ -9,8 +9,8 @@ use crate::errors::{DaachorseError, Result};
 ///
 /// This class manages array elements in fixed-size blocks and supports to extend the array
 /// block by block. Given a constant parameter N, this class maintains information for only
-/// the last N blocks and drops the others according to array extension. We call such last
-/// blocks *active blocks*.
+/// the last N blocks and drops the others according to array extension. Such last blocks are
+/// called *active blocks*.
 #[derive(Default)]
 pub struct BuildHelper {
     items: Vec<ListItem>,
@@ -70,24 +70,40 @@ impl BuildHelper {
     }
 
     /// Checks if the BASE value is used.
+    ///
+    /// # Panic
+    ///
+    /// Panic will arise if active_index_range().contains(&base) == false.
     #[inline(always)]
     pub fn is_used_base(&self, base: u32) -> bool {
         self.get_ref(base).is_used_base()
     }
 
     /// Checks if the index is used.
+    ///
+    /// # Panic
+    ///
+    /// Panic will arise if active_index_range().contains(&idx) == false.
     #[inline(always)]
     pub fn is_used_index(&self, idx: u32) -> bool {
         self.get_ref(idx).is_used_index()
     }
 
     /// Uses the BASE value.
+    ///
+    /// # Panic
+    ///
+    /// Panic will arise if active_index_range().contains(&base) == false.
     #[inline(always)]
     pub fn use_base(&mut self, base: u32) {
         self.get_mut(base).use_base()
     }
 
     /// Uses the index.
+    ///
+    /// # Panic
+    ///
+    /// Panic will arise if active_index_range().contains(&idx) == false.
     #[inline(always)]
     pub fn use_index(&mut self, idx: u32) {
         debug_assert!(!self.get_ref(idx).is_used_index());
@@ -176,7 +192,7 @@ impl BuildHelper {
 
     #[inline(always)]
     fn offset(&self, idx: u32) -> usize {
-        debug_assert!(self.active_index_range().contains(&idx));
+        assert!(self.active_index_range().contains(&idx));
         usize::try_from(idx % self.capacity()).unwrap()
     }
 }

--- a/src/build_helper.rs
+++ b/src/build_helper.rs
@@ -11,7 +11,6 @@ use crate::errors::{DaachorseError, Result};
 /// block by block. Given a constant parameter N, this class maintains information for only
 /// the last N blocks and drops the others according to array extension. Such last blocks are
 /// called *active blocks*.
-#[derive(Default)]
 pub struct BuildHelper {
     items: Vec<ListItem>,
     block_len: u32,

--- a/src/build_helper.rs
+++ b/src/build_helper.rs
@@ -1,0 +1,251 @@
+use core::ops::Range;
+
+use alloc::vec::Vec;
+
+const INVALID_IDX: u32 = u32::MAX;
+
+/// Helper class in double-array construction to maintain indices of vacant elements and
+/// unused BASE values.
+///
+/// This class manages array elements in fixed-size blocks and supports to extend the array
+/// block by block. Given a constant parameter N, this class maintains information for only
+/// the last N blocks and drops the others according to array extension. We call such last
+/// blocks *active blocks*.
+#[derive(Default)]
+pub struct BuildHelper {
+    items: Vec<ListItem>,
+    block_len: u32,
+    num_elements: u32,
+    head_idx: u32,
+}
+
+impl BuildHelper {
+    /// Creates a helper class that handles the last `block_len * num_free_blocks` elements.
+    pub fn new(block_len: u32, num_free_blocks: u32) -> Self {
+        let capacity = usize::try_from(block_len * num_free_blocks).unwrap();
+        assert_ne!(capacity, 0);
+
+        Self {
+            items: vec![ListItem::default(); capacity],
+            block_len,
+            num_elements: 0,
+            head_idx: INVALID_IDX,
+        }
+    }
+
+    /// Gets the number of current double-array elements.
+    #[inline(always)]
+    pub fn num_elements(&self) -> u32 {
+        self.num_elements
+    }
+
+    /// Checks if the next `push_block` can drop information of a block.
+    #[inline(always)]
+    pub fn is_full(&self) -> bool {
+        self.capacity() <= self.num_elements()
+    }
+
+    /// Gets the element index range in the active blocks.
+    #[inline(always)]
+    pub fn active_index_range(&self) -> Range<u32> {
+        let start = self.capacity().max(self.num_elements()) - self.capacity();
+        start..self.num_elements()
+    }
+
+    /// Gets the block position range in the active blocks.
+    #[inline(always)]
+    pub fn active_block_range(&self) -> Range<u32> {
+        let r = self.active_index_range();
+        r.start / self.block_len..r.end / self.block_len
+    }
+
+    /// Creates an iterator to visit vacant indices in the active blocks.
+    #[inline(always)]
+    pub fn vacant_iter(&self) -> VacantIter {
+        let idx = Some(self.head_idx).filter(|&x| x != INVALID_IDX);
+        VacantIter { list: self, idx }
+    }
+
+    /// Gets an unused BASE value in the block.
+    #[inline(always)]
+    pub fn unused_base_in_block(&self, block_idx: u32) -> Option<u32> {
+        let start = block_idx * self.block_len;
+        let end = start + self.block_len;
+        for base in start..end {
+            if !self.is_used_base(base) {
+                return Some(base);
+            }
+        }
+        None
+    }
+
+    /// Checks if the BASE value is used.
+    #[inline(always)]
+    pub fn is_used_base(&self, base: u32) -> bool {
+        self.get_ref(base).is_used_base()
+    }
+
+    /// Checks if the index is used.
+    #[inline(always)]
+    pub fn is_used_index(&self, idx: u32) -> bool {
+        self.get_ref(idx).is_used_index()
+    }
+
+    /// Uses the BASE value.
+    #[inline(always)]
+    pub fn use_base(&mut self, base: u32) {
+        self.get_mut(base).use_base()
+    }
+
+    /// Uses the index.
+    #[inline(always)]
+    pub fn use_index(&mut self, idx: u32) {
+        debug_assert!(!self.get_ref(idx).is_used_index());
+        self.get_mut(idx).use_index();
+
+        let next = self.get_mut(idx).get_next();
+        let prev = self.get_mut(idx).get_prev();
+        self.get_mut(prev).set_next(next);
+        self.get_mut(next).set_prev(prev);
+
+        if self.head_idx == idx {
+            if next == idx {
+                self.head_idx = INVALID_IDX;
+            } else {
+                self.head_idx = next;
+            }
+        }
+    }
+
+    /// Extends the array by pushing a block back.
+    pub fn push_block(&mut self) {
+        if self.is_full() {
+            let closed_block = self.active_block_range().start;
+            let end_idx = (closed_block + 1) * self.block_len;
+            while self.head_idx < end_idx && self.head_idx != INVALID_IDX {
+                self.use_index(self.head_idx);
+            }
+        }
+
+        let old_len = self.num_elements;
+        let new_len = old_len + self.block_len;
+
+        // Update the active index range.
+        self.num_elements = new_len;
+
+        for idx in old_len..new_len {
+            self.reset(idx);
+            self.get_mut(idx).set_next(idx + 1);
+            self.get_mut(idx).set_prev(idx.wrapping_sub(1));
+        }
+
+        if self.head_idx == INVALID_IDX {
+            self.get_mut(old_len).set_prev(new_len - 1);
+            self.get_mut(new_len - 1).set_next(old_len);
+            self.head_idx = old_len;
+        } else {
+            let head_idx = self.head_idx;
+            let tail_idx = self.get_ref(head_idx).get_prev();
+            self.get_mut(old_len).set_prev(tail_idx);
+            self.get_mut(tail_idx).set_next(old_len);
+            self.get_mut(new_len - 1).set_next(head_idx);
+            self.get_mut(head_idx).set_prev(new_len - 1);
+        }
+    }
+
+    #[inline(always)]
+    fn capacity(&self) -> u32 {
+        u32::try_from(self.items.len()).unwrap()
+    }
+
+    #[inline(always)]
+    fn reset(&mut self, idx: u32) {
+        let offset = self.offset(idx);
+        self.items[offset] = ListItem::default();
+    }
+
+    #[inline(always)]
+    fn get_ref(&self, idx: u32) -> &ListItem {
+        &self.items[self.offset(idx)]
+    }
+
+    #[inline(always)]
+    fn get_mut(&mut self, idx: u32) -> &mut ListItem {
+        let offset = self.offset(idx);
+        &mut self.items[offset]
+    }
+
+    #[inline(always)]
+    fn offset(&self, idx: u32) -> usize {
+        debug_assert!(self.active_index_range().contains(&idx));
+        usize::try_from(idx % self.capacity()).unwrap()
+    }
+}
+
+pub struct VacantIter<'a> {
+    list: &'a BuildHelper,
+    idx: Option<u32>,
+}
+
+impl Iterator for VacantIter<'_> {
+    type Item = u32;
+
+    #[inline(always)]
+    fn next(&mut self) -> Option<Self::Item> {
+        let curr = self.idx?;
+        let next = self.list.get_ref(curr).get_next();
+        self.idx = Some(next).filter(|&x| x != self.list.head_idx);
+        Some(curr)
+    }
+}
+
+// TODO: Make memory-efficient.
+#[derive(Default, Clone)]
+pub struct ListItem {
+    next: u32,
+    prev: u32,
+    used_base: bool,
+    used_index: bool,
+}
+
+impl ListItem {
+    #[inline(always)]
+    pub const fn get_next(&self) -> u32 {
+        self.next
+    }
+
+    #[inline(always)]
+    pub const fn get_prev(&self) -> u32 {
+        self.prev
+    }
+
+    #[inline(always)]
+    pub fn set_next(&mut self, x: u32) {
+        self.next = x;
+    }
+
+    #[inline(always)]
+    pub fn set_prev(&mut self, x: u32) {
+        self.prev = x;
+    }
+
+    #[inline(always)]
+    pub const fn is_used_base(&self) -> bool {
+        self.used_base
+    }
+
+    #[inline(always)]
+    pub const fn is_used_index(&self) -> bool {
+        self.used_index
+    }
+
+    #[inline(always)]
+    pub fn use_base(&mut self) {
+        self.used_base = true;
+    }
+
+    #[inline(always)]
+    pub fn use_index(&mut self) {
+        self.used_index = true;
+    }
+}

--- a/src/build_helper.rs
+++ b/src/build_helper.rs
@@ -53,7 +53,7 @@ impl BuildHelper {
 
     /// Creates an iterator to visit vacant indices in the active blocks.
     #[inline(always)]
-    pub fn vacant_iter(&self) -> VacantIter {
+    pub const fn vacant_iter(&self) -> VacantIter {
         VacantIter {
             list: self,
             idx: self.head_idx,

--- a/src/build_helper.rs
+++ b/src/build_helper.rs
@@ -2,6 +2,8 @@ use core::ops::Range;
 
 use alloc::vec::Vec;
 
+use crate::errors::{DaachorseError, Result};
+
 const INVALID_IDX: u32 = u32::MAX;
 
 /// Helper class in double-array construction to maintain indices of vacant elements and
@@ -112,7 +114,11 @@ impl BuildHelper {
     }
 
     /// Extends the array by pushing a block back.
-    pub fn push_block(&mut self) {
+    pub fn push_block(&mut self) -> Result<()> {
+        if self.num_elements > u32::MAX - self.block_len {
+            return Err(DaachorseError::automaton_scale("num_elements", u32::MAX));
+        }
+
         if let Some(closed_block) = self.dropped_block() {
             let end_idx = (closed_block + 1) * self.block_len;
             while self.head_idx < end_idx && self.head_idx != INVALID_IDX {
@@ -144,6 +150,8 @@ impl BuildHelper {
             self.get_mut(new_len - 1).set_next(head_idx);
             self.get_mut(head_idx).set_prev(new_len - 1);
         }
+
+        Ok(())
     }
 
     /// Retruns the index of an active block that will be dropped in the next `push_block`.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -20,7 +20,6 @@ pub struct DoubleArrayAhoCorasickBuilder {
     states: Vec<State>,
     helper: BuildHelper,
     match_kind: MatchKind,
-    num_free_blocks: u32,
 }
 
 impl Default for DoubleArrayAhoCorasickBuilder {
@@ -56,9 +55,8 @@ impl DoubleArrayAhoCorasickBuilder {
     pub fn new() -> Self {
         Self {
             states: vec![],
-            helper: BuildHelper::default(),
+            helper: BuildHelper::new(BLOCK_LEN, 16),
             match_kind: MatchKind::Standard,
-            num_free_blocks: 16,
         }
     }
 
@@ -109,9 +107,9 @@ impl DoubleArrayAhoCorasickBuilder {
     ///
     /// `n` must be greater than or equal to 1.
     #[must_use]
-    pub const fn num_free_blocks(mut self, n: u32) -> Self {
+    pub fn num_free_blocks(mut self, n: u32) -> Self {
         assert!(n >= 1);
-        self.num_free_blocks = n;
+        self.helper = BuildHelper::new(BLOCK_LEN, n);
         self
     }
 
@@ -320,7 +318,6 @@ impl DoubleArrayAhoCorasickBuilder {
     fn init_array(&mut self) {
         self.states
             .resize(usize::try_from(BLOCK_LEN).unwrap(), State::default());
-        self.helper = BuildHelper::new(BLOCK_LEN, self.num_free_blocks);
         self.helper.push_block().unwrap();
         self.helper.use_index(ROOT_STATE_IDX);
         self.helper.use_index(DEAD_STATE_IDX);

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -356,8 +356,7 @@ impl DoubleArrayAhoCorasickBuilder {
             return Err(DaachorseError::automaton_scale("states.len()", u32::MAX));
         }
 
-        if self.helper.is_full() {
-            let closed_block_idx = self.helper.active_block_range().start;
+        if let Some(closed_block_idx) = self.helper.dropped_block() {
             self.remove_invalid_checks(closed_block_idx);
         }
 
@@ -367,7 +366,8 @@ impl DoubleArrayAhoCorasickBuilder {
         Ok(())
     }
 
-    /// Embeds all CHECK values in the block to avoid invalid transitions.
+    /// Embeds valid CHECK values for all vacant elements in the block
+    /// to avoid invalid transitions.
     fn remove_invalid_checks(&mut self, block_idx: u32) {
         if let Some(unused_base) = self.helper.unused_base_in_block(block_idx) {
             for c in 0..=BLOCK_MAX {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -3,7 +3,8 @@ use alloc::vec::Vec;
 use crate::errors::{DaachorseError, Result};
 use crate::nfa_builder::{NfaBuilder, DEAD_STATE_ID, ROOT_STATE_ID};
 use crate::{
-    DoubleArrayAhoCorasick, MatchKind, State, DEAD_STATE_IDX, OUTPUT_POS_MAX, ROOT_STATE_IDX,
+    BuildHelper, DoubleArrayAhoCorasick, MatchKind, State, DEAD_STATE_IDX, OUTPUT_POS_MAX,
+    ROOT_STATE_IDX,
 };
 
 // The maximum value of each double-array block.
@@ -14,72 +15,10 @@ const BLOCK_LEN: u32 = BLOCK_MAX as u32 + 1;
 // Specialized [`NfaBuilder`] handling labels of `u8`.
 type BytewiseNfaBuilder = NfaBuilder<u8>;
 
-#[derive(Clone, Copy)]
-struct Extra {
-    used_base: bool,
-    used_index: bool,
-    next: u32,
-    prev: u32,
-}
-
-impl Default for Extra {
-    fn default() -> Self {
-        Self {
-            used_base: false,
-            used_index: false,
-            next: DEAD_STATE_IDX,
-            prev: DEAD_STATE_IDX,
-        }
-    }
-}
-
-impl Extra {
-    #[inline(always)]
-    const fn get_next(&self) -> u32 {
-        self.next
-    }
-
-    #[inline(always)]
-    const fn get_prev(&self) -> u32 {
-        self.prev
-    }
-
-    #[inline(always)]
-    fn set_next(&mut self, x: u32) {
-        self.next = x;
-    }
-
-    #[inline(always)]
-    fn set_prev(&mut self, x: u32) {
-        self.prev = x;
-    }
-
-    #[inline(always)]
-    const fn is_used_base(&self) -> bool {
-        self.used_base
-    }
-
-    #[inline(always)]
-    const fn is_used_index(&self) -> bool {
-        self.used_index
-    }
-
-    #[inline(always)]
-    fn use_base(&mut self) {
-        self.used_base = true;
-    }
-
-    #[inline(always)]
-    fn use_index(&mut self) {
-        self.used_index = true;
-    }
-}
-
 /// Builder of [`DoubleArrayAhoCorasick`].
 pub struct DoubleArrayAhoCorasickBuilder {
     states: Vec<State>,
-    extras: Vec<Extra>,
-    head_idx: u32,
+    helper: BuildHelper,
     match_kind: MatchKind,
     num_free_blocks: u32,
 }
@@ -114,11 +53,10 @@ impl DoubleArrayAhoCorasickBuilder {
     /// assert_eq!(None, it.next());
     /// ```
     #[must_use]
-    pub const fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             states: vec![],
-            extras: vec![],
-            head_idx: DEAD_STATE_IDX,
+            helper: BuildHelper::default(),
             match_kind: MatchKind::Standard,
             num_free_blocks: 16,
         }
@@ -340,13 +278,13 @@ impl DoubleArrayAhoCorasickBuilder {
 
             for (&c, &child_id) in &s.edges {
                 let child_idx = base ^ u32::from(c);
-                self.fix_state(child_idx);
+                self.helper.use_index(child_idx);
                 self.states[child_idx as usize].set_check(c);
                 state_id_map[child_id as usize] = child_idx;
                 stack.push(child_id);
             }
             self.states[state_idx].set_base(base);
-            self.extra_mut_ref(base).use_base();
+            self.helper.use_base(base);
         }
 
         // Sets fail & output_pos values
@@ -371,81 +309,29 @@ impl DoubleArrayAhoCorasickBuilder {
             }
         }
 
-        // If the root block has not been closed, it has to be closed for setting CHECK[0] to a valid value.
-        if self.states.len() <= self.extras.len() {
-            self.close_block(0);
+        for closed_block_idx in self.helper.active_block_range() {
+            self.remove_invalid_checks(closed_block_idx);
         }
-
-        while self.head_idx != DEAD_STATE_IDX {
-            let block_idx = self.head_idx / BLOCK_LEN;
-            self.close_block(block_idx);
-        }
-
         self.states.shrink_to_fit();
 
         Ok(())
     }
 
     fn init_array(&mut self) {
-        self.states.resize(BLOCK_LEN as usize, State::default());
-        self.extras.resize(
-            (BLOCK_LEN * self.num_free_blocks) as usize,
-            Extra::default(),
-        );
-        self.head_idx = ROOT_STATE_IDX;
-
-        for i in 0..BLOCK_LEN {
-            self.init_extra(i);
-            if i == 0 {
-                self.extra_mut_ref(i).set_prev(BLOCK_LEN - 1);
-            } else {
-                self.extra_mut_ref(i).set_prev(i - 1);
-            }
-            if i == BLOCK_LEN - 1 {
-                self.extra_mut_ref(i).set_next(0);
-            } else {
-                self.extra_mut_ref(i).set_next(i + 1);
-            }
-        }
-
-        self.fix_state(ROOT_STATE_IDX);
-        self.fix_state(DEAD_STATE_IDX);
-    }
-
-    #[inline(always)]
-    fn fix_state(&mut self, i: u32) {
-        debug_assert!(!self.extra_ref(i).is_used_index());
-        self.extra_mut_ref(i).use_index();
-
-        let next = self.extra_ref(i).get_next();
-        let prev = self.extra_ref(i).get_prev();
-        self.extra_mut_ref(prev).set_next(next);
-        self.extra_mut_ref(next).set_prev(prev);
-
-        if self.head_idx == i {
-            if next == i {
-                self.head_idx = DEAD_STATE_IDX;
-            } else {
-                self.head_idx = next;
-            }
-        }
+        self.states
+            .resize(usize::try_from(BLOCK_LEN).unwrap(), State::default());
+        self.helper = BuildHelper::new(BLOCK_LEN, self.num_free_blocks);
+        self.helper.push_block();
+        self.helper.use_index(ROOT_STATE_IDX);
+        self.helper.use_index(DEAD_STATE_IDX);
     }
 
     #[inline(always)]
     fn find_base(&self, labels: &[u8]) -> u32 {
-        if self.head_idx == DEAD_STATE_IDX {
-            return self.states.len().try_into().unwrap();
-        }
-        let mut idx = self.head_idx;
-        loop {
-            debug_assert!(!self.extra_ref(idx).is_used_index());
+        for idx in self.helper.vacant_iter() {
             let base = idx ^ u32::from(labels[0]);
             if self.check_valid_base(base, labels) {
                 return base;
-            }
-            idx = self.extra_ref(idx).get_next();
-            if idx == self.head_idx {
-                break;
             }
         }
         self.states.len().try_into().unwrap()
@@ -453,12 +339,12 @@ impl DoubleArrayAhoCorasickBuilder {
 
     #[inline(always)]
     fn check_valid_base(&self, base: u32, labels: &[u8]) -> bool {
-        if self.extra_ref(base).is_used_base() {
+        if self.helper.is_used_base(base) {
             return false;
         }
         for &c in labels {
             let idx = base ^ u32::from(c);
-            if self.extra_ref(idx).is_used_index() {
+            if self.helper.is_used_index(idx) {
                 return false;
             }
         }
@@ -466,102 +352,31 @@ impl DoubleArrayAhoCorasickBuilder {
     }
 
     fn extend_array(&mut self) -> Result<()> {
-        let old_len = self.states.len().try_into().unwrap();
-        // The following condition is same as `new_len > STATE_INDEX_IVALID`.
-        // We use the following condition to avoid overflow.
-        if old_len > u32::MAX - BLOCK_LEN {
+        if u32::try_from(self.states.len()).unwrap() > u32::MAX - BLOCK_LEN {
             return Err(DaachorseError::automaton_scale("states.len()", u32::MAX));
         }
-        let new_len = old_len + BLOCK_LEN;
 
-        // It is necessary to close the head block before appending a new block
-        // so that the builder works in extras[..FREE_STATES].
-        if self.extras.len() <= old_len as usize {
-            #[allow(clippy::cast_possible_truncation)]
-            self.close_block((old_len - self.extras.len() as u32) / BLOCK_LEN);
+        if self.helper.is_full() {
+            let closed_block_idx = self.helper.active_block_range().start;
+            self.remove_invalid_checks(closed_block_idx);
         }
 
-        for i in old_len..new_len {
-            self.states.push(State::default());
-            self.init_extra(i);
-            self.extra_mut_ref(i).set_next(i + 1);
-            self.extra_mut_ref(i).set_prev(i - 1);
-        }
-
-        if self.head_idx == DEAD_STATE_IDX {
-            self.extra_mut_ref(old_len).set_prev(new_len - 1);
-            self.extra_mut_ref(new_len - 1).set_next(old_len);
-            self.head_idx = old_len;
-        } else {
-            let head_idx = self.head_idx;
-            let tail_idx = self.extra_ref(head_idx).get_prev();
-            self.extra_mut_ref(old_len).set_prev(tail_idx);
-            self.extra_mut_ref(tail_idx).set_next(old_len);
-            self.extra_mut_ref(new_len - 1).set_next(head_idx);
-            self.extra_mut_ref(head_idx).set_prev(new_len - 1);
-        }
+        self.helper.push_block();
+        (0..BLOCK_LEN).for_each(|_| self.states.push(State::default()));
 
         Ok(())
     }
 
-    /// Note: Assumes all the previous blocks are closed.
-    fn close_block(&mut self, block_idx: u32) {
-        let beg_idx = block_idx * BLOCK_LEN;
-        let end_idx = beg_idx + BLOCK_LEN;
-
-        if block_idx == 0 || self.head_idx < end_idx {
-            self.remove_invalid_checks(block_idx);
-        }
-        while self.head_idx < end_idx && self.head_idx != DEAD_STATE_IDX {
-            self.fix_state(self.head_idx);
-        }
-    }
-
+    /// Embeds all CHECK values in the block to avoid invalid transitions.
     fn remove_invalid_checks(&mut self, block_idx: u32) {
-        let beg_idx = block_idx * BLOCK_LEN;
-        let end_idx = beg_idx + BLOCK_LEN;
-
-        let unused_base = {
-            let mut i = beg_idx;
-            while i < end_idx {
-                if !self.extra_ref(i).is_used_base() {
-                    break;
+        if let Some(unused_base) = self.helper.unused_base_in_block(block_idx) {
+            for c in 0..=BLOCK_MAX {
+                let idx = unused_base ^ u32::from(c);
+                if idx == ROOT_STATE_IDX || idx == DEAD_STATE_IDX || !self.helper.is_used_index(idx)
+                {
+                    self.states[idx as usize].set_check(c);
                 }
-                i += 1;
-            }
-            i
-        };
-        debug_assert_ne!(unused_base, end_idx);
-
-        for c in 0..=BLOCK_MAX {
-            let idx = unused_base ^ u32::from(c);
-            if idx == ROOT_STATE_IDX
-                || idx == DEAD_STATE_IDX
-                || !self.extra_ref(idx).is_used_index()
-            {
-                self.states[idx as usize].set_check(c);
             }
         }
-    }
-
-    #[inline(always)]
-    fn init_extra(&mut self, i: u32) {
-        let free_states = self.extras.len();
-        debug_assert!(self.states.len() <= i as usize + free_states);
-        self.extras[i as usize % free_states] = Extra::default();
-    }
-
-    #[inline(always)]
-    fn extra_ref(&self, i: u32) -> &Extra {
-        let free_states = self.extras.len();
-        debug_assert!(self.states.len() <= i as usize + free_states);
-        &self.extras[i as usize % free_states]
-    }
-
-    #[inline(always)]
-    fn extra_mut_ref(&mut self, i: u32) -> &mut Extra {
-        let free_states = self.extras.len();
-        debug_assert!(self.states.len() <= i as usize + free_states);
-        &mut self.extras[i as usize % free_states]
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -321,7 +321,7 @@ impl DoubleArrayAhoCorasickBuilder {
         self.states
             .resize(usize::try_from(BLOCK_LEN).unwrap(), State::default());
         self.helper = BuildHelper::new(BLOCK_LEN, self.num_free_blocks);
-        self.helper.push_block();
+        self.helper.push_block().unwrap();
         self.helper.use_index(ROOT_STATE_IDX);
         self.helper.use_index(DEAD_STATE_IDX);
     }
@@ -360,7 +360,7 @@ impl DoubleArrayAhoCorasickBuilder {
             self.remove_invalid_checks(closed_block_idx);
         }
 
-        self.helper.push_block();
+        self.helper.push_block()?;
         (0..BLOCK_LEN).for_each(|_| self.states.push(State::default()));
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,7 @@ compile_error!("`target_pointer_width` must be larger than or equal to 32");
 #[macro_use]
 extern crate alloc;
 
+mod build_helper;
 mod builder;
 pub mod charwise;
 pub mod errors;
@@ -173,6 +174,7 @@ use alloc::vec::Vec;
 #[cfg(feature = "std")]
 use std::io::{self, Read, Write};
 
+use build_helper::BuildHelper;
 pub use builder::DoubleArrayAhoCorasickBuilder;
 use errors::{DaachorseError, Result};
 use iter::{


### PR DESCRIPTION
This PR divided `Extra` from `builder.rs` and generalized the auxiliary data structure in double-array construction.
`BuildHelper` can be used in both the cases of bytewise and charwise, although I will modify `charwise/builder.rs` in another PR.