### PR TITLE
Use BuildHelper in Charwise

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -360,7 +360,10 @@ impl DoubleArrayAhoCorasickBuilder {
         }
 
         helper.push_block()?;
-        (0..BLOCK_LEN).for_each(|_| self.states.push(State::default()));
+        self.states.resize(
+            self.states.len() + usize::try_from(BLOCK_LEN).unwrap(),
+            State::default(),
+        );
 
         Ok(())
     }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -351,7 +351,7 @@ impl DoubleArrayAhoCorasickBuilder {
     }
 
     fn extend_array(&mut self, helper: &mut BuildHelper) -> Result<()> {
-        if u32::try_from(self.states.len()).unwrap() > u32::MAX - BLOCK_LEN {
+        if self.states.len() > usize::try_from(u32::MAX - BLOCK_LEN).unwrap() {
             return Err(DaachorseError::automaton_scale("states.len()", u32::MAX));
         }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -52,7 +52,7 @@ impl DoubleArrayAhoCorasickBuilder {
     /// assert_eq!(None, it.next());
     /// ```
     #[must_use]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             states: vec![],
             match_kind: MatchKind::Standard,

--- a/src/charwise/builder.rs
+++ b/src/charwise/builder.rs
@@ -338,7 +338,10 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
         }
 
         helper.push_block()?;
-        (0..self.block_len).for_each(|_| self.states.push(State::default()));
+        self.states.resize(
+            self.states.len() + usize::try_from(self.block_len).unwrap(),
+            State::default(),
+        );
 
         Ok(())
     }

--- a/src/charwise/builder.rs
+++ b/src/charwise/builder.rs
@@ -333,7 +333,7 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
 
     #[inline(always)]
     fn extend_array(&mut self, helper: &mut BuildHelper) -> Result<()> {
-        if u32::try_from(self.states.len()).unwrap() > u32::MAX - self.block_len {
+        if self.states.len() > usize::try_from(u32::MAX - self.block_len).unwrap() {
             return Err(DaachorseError::automaton_scale("states.len()", u32::MAX));
         }
 


### PR DESCRIPTION
This PR used `BuildHelper` in Charwise.
Also, I modified `DoubleArrayAhoCorasickBuilder` in Bytewise to create an instance of `BuildHelper` in function `build_double_array` instead of maintaining it as a struct member, because `num_free_blocks` drops an older instance.