### PR TITLE
Check overflow in BuildHelper

### DIFF
--- a/src/build_helper.rs
+++ b/src/build_helper.rs
@@ -20,16 +20,19 @@ pub struct BuildHelper {
 
 impl BuildHelper {
     /// Creates a helper class that handles the last `block_len * num_free_blocks` elements.
-    pub fn new(block_len: u32, num_free_blocks: u32) -> Self {
-        let capacity = usize::try_from(block_len * num_free_blocks).unwrap();
+    pub fn new(block_len: u32, num_free_blocks: u32) -> Result<Self> {
+        let capacity = block_len.checked_mul(num_free_blocks).ok_or_else(|| {
+            DaachorseError::automaton_scale("block_len * num_free_blocks", u32::MAX)
+        })?;
+        let capacity = usize::try_from(capacity).unwrap();
         assert_ne!(capacity, 0);
 
-        Self {
+        Ok(Self {
             items: vec![ListItem::default(); capacity],
             block_len,
             num_elements: 0,
             head_idx: None,
-        }
+        })
     }
 
     /// Gets the number of current double-array elements.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -245,7 +245,7 @@ impl DoubleArrayAhoCorasickBuilder {
     }
 
     fn build_double_array(&mut self, nfa: &BytewiseNfaBuilder) -> Result<()> {
-        let mut helper = self.init_array();
+        let mut helper = self.init_array()?;
 
         let mut state_id_map = vec![DEAD_STATE_IDX; nfa.states.len()];
         state_id_map[ROOT_STATE_ID as usize] = ROOT_STATE_IDX;
@@ -315,14 +315,14 @@ impl DoubleArrayAhoCorasickBuilder {
         Ok(())
     }
 
-    fn init_array(&mut self) -> BuildHelper {
+    fn init_array(&mut self) -> Result<BuildHelper> {
         self.states
             .resize(usize::try_from(BLOCK_LEN).unwrap(), State::default());
-        let mut helper = BuildHelper::new(BLOCK_LEN, self.num_free_blocks);
+        let mut helper = BuildHelper::new(BLOCK_LEN, self.num_free_blocks)?;
         helper.push_block().unwrap();
         helper.use_index(ROOT_STATE_IDX);
         helper.use_index(DEAD_STATE_IDX);
-        helper
+        Ok(helper)
     }
 
     #[inline(always)]

--- a/src/charwise/builder.rs
+++ b/src/charwise/builder.rs
@@ -228,7 +228,7 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
     }
 
     fn build_double_array(&mut self, nfa: &CharwiseNfaBuilder) -> Result<()> {
-        let mut helper = self.init_array();
+        let mut helper = self.init_array()?;
 
         let mut state_id_map = vec![DEAD_STATE_IDX; nfa.states.len()];
         state_id_map[ROOT_STATE_ID as usize] = ROOT_STATE_IDX;
@@ -296,15 +296,15 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
         Ok(())
     }
 
-    fn init_array(&mut self) -> BuildHelper {
+    fn init_array(&mut self) -> Result<BuildHelper> {
         self.block_len = self.mapper.alphabet_size().next_power_of_two().max(2);
         self.states
             .resize(usize::try_from(self.block_len).unwrap(), State::default());
-        let mut helper = BuildHelper::new(self.block_len, self.num_free_blocks);
+        let mut helper = BuildHelper::new(self.block_len, self.num_free_blocks)?;
         helper.push_block().unwrap();
         helper.use_index(ROOT_STATE_IDX);
         helper.use_index(DEAD_STATE_IDX);
-        helper
+        Ok(helper)
     }
 
     #[inline(always)]

--- a/tests/invalid_option_test.rs
+++ b/tests/invalid_option_test.rs
@@ -1,0 +1,9 @@
+use daachorse::DoubleArrayAhoCorasickBuilder;
+
+#[test]
+fn test_large_num_free_blocks() {
+    assert!(DoubleArrayAhoCorasickBuilder::new()
+        .num_free_blocks(u32::MAX)
+        .build(["pattern"])
+        .is_err());
+}


### PR DESCRIPTION
If users specify the large number to `num_free_blocks`, the capacity size will be wrapped. This branch checks the value before calculating the capacity size.

Blocked by #52 