### PR TITLE
Fully eliminate std dependencies

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,7 +77,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --release --no-default-features
+          args: --release --no-default-features --features alloc
 
       - name: Run cargo doc
         uses: actions-rs/cargo@v1
@@ -121,7 +121,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --release --no-default-features
+          args: --release --no-default-features --features alloc
 
 
       - name: Run cargo doc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,9 @@ exclude = [".*"]
 [dev-dependencies]
 
 [features]
-default = ["std"]
+default = ["alloc"]
 
-std = []
+alloc = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ assert_eq!(None, it.next());
 
 ## `no_std`
 
-To use this crate in a `no_std` environment, disable feature `std`.
+Daachorse has no dependency on `std`.
 
 ## CLI
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ assert_eq!(None, it.next());
 
 ## `no_std`
 
-Daachorse has no dependency on `std`.
+Daachorse has no dependency on `std` (but requires a global allocator with the `alloc` crate).
 
 ## CLI
 

--- a/daacfind/src/main.rs
+++ b/daacfind/src/main.rs
@@ -135,7 +135,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
     }
-    let pma = DoubleArrayAhoCorasick::new(patterns)?;
+    let pma = DoubleArrayAhoCorasick::new(patterns).map_err(|e| format!("{}", e))?;
 
     // Initialize the stream of termcolor.
     let mut stdout = match args.color {

--- a/src/bytewise.rs
+++ b/src/bytewise.rs
@@ -8,9 +8,6 @@ use core::num::NonZeroU32;
 
 use alloc::vec::Vec;
 
-#[cfg(feature = "std")]
-use std::io::{self, Read, Write};
-
 use crate::build_helper::BuildHelper;
 use crate::errors::{DaachorseError, Result};
 use crate::intpack::{U24nU8, U24};
@@ -558,46 +555,6 @@ impl DoubleArrayAhoCorasick {
         self.num_states
     }
 
-    /// Serializes the automaton into a given target.
-    ///
-    /// # Arguments
-    ///
-    /// * `wtr` - A writable target.
-    ///
-    /// # Errors
-    ///
-    /// This function will return errors thrown by the given `wtr`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use daachorse::DoubleArrayAhoCorasick;
-    ///
-    /// let mut bytes = vec![];
-    ///
-    /// let patterns = vec!["bcd", "ab", "a"];
-    /// let pma = DoubleArrayAhoCorasick::new(patterns).unwrap();
-    /// pma.serialize(&mut bytes).unwrap();
-    /// ```
-    #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    pub fn serialize<W>(&self, mut wtr: W) -> io::Result<()>
-    where
-        W: Write,
-    {
-        wtr.write_all(&u32::try_from(self.states.len()).unwrap().to_le_bytes())?;
-        for state in &self.states {
-            wtr.write_all(&state.serialize())?;
-        }
-        wtr.write_all(&u32::try_from(self.outputs.len()).unwrap().to_le_bytes())?;
-        for output in &self.outputs {
-            wtr.write_all(&output.serialize())?;
-        }
-        wtr.write_all(&[self.match_kind as u8])?;
-        wtr.write_all(&u32::try_from(self.num_states).unwrap().to_le_bytes())?;
-        Ok(())
-    }
-
     /// Serializes the automaton into a [`Vec`].
     ///
     /// # Examples
@@ -628,95 +585,6 @@ impl DoubleArrayAhoCorasick {
         result.push(self.match_kind as u8);
         result.extend_from_slice(&u32::try_from(self.num_states).unwrap().to_le_bytes());
         result
-    }
-
-    /// Deserializes the automaton from a given source.
-    ///
-    /// # Arguments
-    ///
-    /// * `rdr` - A readable source.
-    ///
-    /// # Errors
-    ///
-    /// This function will return errors thrown by the given `rdr`.
-    ///
-    /// # Safety
-    ///
-    /// The given data must be a correct automaton exported by
-    /// [`DoubleArrayAhoCorasick::serialize()`] or
-    /// [`DoubleArrayAhoCorasick::serialize_to_vec()`] functions.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use std::io::Read;
-    ///
-    /// use daachorse::DoubleArrayAhoCorasick;
-    ///
-    /// let mut bytes = vec![];
-    ///
-    /// {
-    ///     let patterns = vec!["bcd", "ab", "a"];
-    ///     let pma = DoubleArrayAhoCorasick::new(patterns).unwrap();
-    ///     pma.serialize(&mut bytes).unwrap();
-    /// }
-    ///
-    /// let pma = unsafe {
-    ///     DoubleArrayAhoCorasick::deserialize_unchecked(&mut bytes.as_slice()).unwrap()
-    /// };
-    ///
-    /// let mut it = pma.find_overlapping_iter("abcd");
-    ///
-    /// let m = it.next().unwrap();
-    /// assert_eq!((0, 1, 2), (m.start(), m.end(), m.value()));
-    ///
-    /// let m = it.next().unwrap();
-    /// assert_eq!((0, 2, 1), (m.start(), m.end(), m.value()));
-    ///
-    /// let m = it.next().unwrap();
-    /// assert_eq!((1, 4, 0), (m.start(), m.end(), m.value()));
-    ///
-    /// assert_eq!(None, it.next());
-    /// ```
-    #[cfg(feature = "std")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
-    pub unsafe fn deserialize_unchecked<R>(mut rdr: R) -> io::Result<Self>
-    where
-        R: Read,
-    {
-        let mut states_len_array = [0; 4];
-        rdr.read_exact(&mut states_len_array)?;
-        let states_len = u32::from_le_bytes(states_len_array) as usize;
-        let mut states = Vec::with_capacity(states_len);
-        for _ in 0..states_len {
-            let mut state_array = [0; 12];
-            rdr.read_exact(&mut state_array)?;
-            states.push(State::deserialize(state_array));
-        }
-        let mut outputs_len_array = [0; 4];
-        rdr.read_exact(&mut outputs_len_array)?;
-        let outputs_len = u32::from_le_bytes(outputs_len_array) as usize;
-        let mut outputs = Vec::with_capacity(outputs_len);
-        for _ in 0..outputs_len {
-            let mut output_array = [0; 12];
-            rdr.read_exact(&mut output_array)?;
-            outputs.push(Output::deserialize(output_array));
-        }
-
-        let mut match_kind_array = [0];
-        rdr.read_exact(&mut match_kind_array)?;
-        let match_kind = MatchKind::from(match_kind_array[0]);
-
-        let mut num_states_array = [0; 4];
-        rdr.read_exact(&mut num_states_array)?;
-        let num_states = u32::from_le_bytes(num_states_array) as usize;
-
-        Ok(Self {
-            states,
-            outputs,
-            match_kind,
-            num_states,
-        })
     }
 
     /// Deserializes the automaton from a given slice.

--- a/src/bytewise.rs
+++ b/src/bytewise.rs
@@ -564,10 +564,10 @@ impl DoubleArrayAhoCorasick {
     ///
     /// let patterns = vec!["bcd", "ab", "a"];
     /// let pma = DoubleArrayAhoCorasick::new(patterns).unwrap();
-    /// let bytes = pma.serialize_to_vec();
+    /// let bytes = pma.serialize();
     /// ```
     #[must_use]
-    pub fn serialize_to_vec(&self) -> Vec<u8> {
+    pub fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::with_capacity(
             mem::size_of::<u32>() * 3
                 + mem::size_of::<u8>()
@@ -600,7 +600,7 @@ impl DoubleArrayAhoCorasick {
     /// # Safety
     ///
     /// The given data must be a correct automaton exported by
-    /// [`DoubleArrayAhoCorasick::serialize_to_vec()`] function.
+    /// [`DoubleArrayAhoCorasick::serialize()`] function.
     ///
     /// # Examples
     ///
@@ -609,10 +609,10 @@ impl DoubleArrayAhoCorasick {
     ///
     /// let patterns = vec!["bcd", "ab", "a"];
     /// let pma = DoubleArrayAhoCorasick::new(patterns).unwrap();
-    /// let bytes = pma.serialize_to_vec();
+    /// let bytes = pma.serialize();
     ///
     /// let (pma, _) = unsafe {
-    ///     DoubleArrayAhoCorasick::deserialize_from_slice_unchecked(&bytes)
+    ///     DoubleArrayAhoCorasick::deserialize_unchecked(&bytes)
     /// };
     ///
     /// let mut it = pma.find_overlapping_iter("abcd");
@@ -629,7 +629,7 @@ impl DoubleArrayAhoCorasick {
     /// assert_eq!(None, it.next());
     /// ```
     #[must_use]
-    pub unsafe fn deserialize_from_slice_unchecked(mut source: &[u8]) -> (Self, &[u8]) {
+    pub unsafe fn deserialize_unchecked(mut source: &[u8]) -> (Self, &[u8]) {
         let states_len = u32::from_le_bytes(source[0..4].try_into().unwrap()) as usize;
         source = &source[4..];
         let mut states = Vec::with_capacity(states_len);

--- a/src/bytewise.rs
+++ b/src/bytewise.rs
@@ -600,8 +600,7 @@ impl DoubleArrayAhoCorasick {
     /// # Safety
     ///
     /// The given data must be a correct automaton exported by
-    /// [`DoubleArrayAhoCorasick::serialize()`] or
-    /// [`DoubleArrayAhoCorasick::serialize_to_vec()`] functions.
+    /// [`DoubleArrayAhoCorasick::serialize_to_vec()`] function.
     ///
     /// # Examples
     ///

--- a/src/charwise.rs
+++ b/src/charwise.rs
@@ -636,8 +636,7 @@ impl CharwiseDoubleArrayAhoCorasick {
     /// # Safety
     ///
     /// The given data must be a correct automaton exported by
-    /// [`CharwiseDoubleArrayAhoCorasick::serialize()`] or
-    /// [`CharwiseDoubleArrayAhoCorasick::serialize_to_vec()`] functions.
+    /// [`CharwiseDoubleArrayAhoCorasick::serialize_to_vec()`] function.
     ///
     /// # Examples
     ///

--- a/src/charwise.rs
+++ b/src/charwise.rs
@@ -598,10 +598,10 @@ impl CharwiseDoubleArrayAhoCorasick {
     ///
     /// let patterns = vec!["全世界", "世界", "に"];
     /// let pma = CharwiseDoubleArrayAhoCorasick::new(patterns).unwrap();
-    /// let bytes = pma.serialize_to_vec();
+    /// let bytes = pma.serialize();
     /// ```
     #[must_use]
-    pub fn serialize_to_vec(&self) -> Vec<u8> {
+    pub fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::with_capacity(
             mem::size_of::<u32>() * 3
                 + mem::size_of::<u8>()
@@ -613,7 +613,7 @@ impl CharwiseDoubleArrayAhoCorasick {
         for state in &self.states {
             result.extend_from_slice(&state.serialize());
         }
-        self.mapper.serialize_into_vec(&mut result);
+        self.mapper.serialize(&mut result);
         result.extend_from_slice(&u32::try_from(self.outputs.len()).unwrap().to_le_bytes());
         for output in &self.outputs {
             result.extend_from_slice(&output.serialize());
@@ -636,7 +636,7 @@ impl CharwiseDoubleArrayAhoCorasick {
     /// # Safety
     ///
     /// The given data must be a correct automaton exported by
-    /// [`CharwiseDoubleArrayAhoCorasick::serialize_to_vec()`] function.
+    /// [`CharwiseDoubleArrayAhoCorasick::serialize()`] function.
     ///
     /// # Examples
     ///
@@ -645,10 +645,10 @@ impl CharwiseDoubleArrayAhoCorasick {
     ///
     /// let patterns = vec!["全世界", "世界", "に"];
     /// let pma = CharwiseDoubleArrayAhoCorasick::new(patterns).unwrap();
-    /// let bytes = pma.serialize_to_vec();
+    /// let bytes = pma.serialize();
     ///
     /// let (pma, _) = unsafe {
-    ///     CharwiseDoubleArrayAhoCorasick::deserialize_from_slice_unchecked(&bytes)
+    ///     CharwiseDoubleArrayAhoCorasick::deserialize_unchecked(&bytes)
     /// };
     ///
     /// let mut it = pma.find_overlapping_iter("全世界中に");
@@ -665,7 +665,7 @@ impl CharwiseDoubleArrayAhoCorasick {
     /// assert_eq!(None, it.next());
     /// ```
     #[must_use]
-    pub unsafe fn deserialize_from_slice_unchecked(mut source: &[u8]) -> (Self, &[u8]) {
+    pub unsafe fn deserialize_unchecked(mut source: &[u8]) -> (Self, &[u8]) {
         let states_len = u32::from_le_bytes(source[0..4].try_into().unwrap()) as usize;
         source = &source[4..];
         let mut states = Vec::with_capacity(states_len);
@@ -674,7 +674,7 @@ impl CharwiseDoubleArrayAhoCorasick {
             source = &source[16..];
         }
 
-        let (mapper, mut source) = CodeMapper::deserialize_from_slice_unchecked(source);
+        let (mapper, mut source) = CodeMapper::deserialize_unchecked(source);
 
         let outputs_len = u32::from_le_bytes(source[0..4].try_into().unwrap()) as usize;
         source = &source[4..];

--- a/src/charwise/mapper.rs
+++ b/src/charwise/mapper.rs
@@ -54,7 +54,7 @@ impl CodeMapper {
             + core::mem::size_of::<u32>() // alphabet_size
     }
 
-    pub fn serialize_into_vec(&self, result: &mut Vec<u8>) {
+    pub fn serialize(&self, result: &mut Vec<u8>) {
         result.extend_from_slice(&u32::try_from(self.table.len()).unwrap().to_le_bytes());
         for &x in &self.table {
             result.extend_from_slice(&x.to_le_bytes());
@@ -62,7 +62,7 @@ impl CodeMapper {
         result.extend_from_slice(&self.alphabet_size.to_le_bytes());
     }
 
-    pub unsafe fn deserialize_from_slice_unchecked(mut source: &[u8]) -> (Self, &[u8]) {
+    pub unsafe fn deserialize_unchecked(mut source: &[u8]) -> (Self, &[u8]) {
         let len = u32::from_le_bytes(source[0..4].try_into().unwrap()) as usize;
         source = &source[4..];
         let mut table = Vec::with_capacity(len);

--- a/src/charwise/mapper.rs
+++ b/src/charwise/mapper.rs
@@ -1,6 +1,3 @@
-#[cfg(feature = "std")]
-use std::io::{self, Read, Write};
-
 use alloc::vec::Vec;
 
 pub const INVALID_CODE: u32 = u32::MAX;
@@ -57,48 +54,12 @@ impl CodeMapper {
             + core::mem::size_of::<u32>() // alphabet_size
     }
 
-    #[cfg(feature = "std")]
-    pub fn serialize<W>(&self, mut wtr: W) -> io::Result<()>
-    where
-        W: Write,
-    {
-        wtr.write_all(&u32::try_from(self.table.len()).unwrap().to_le_bytes())?;
-        for &x in &self.table {
-            wtr.write_all(&x.to_le_bytes())?;
-        }
-        wtr.write_all(&self.alphabet_size.to_le_bytes())?;
-        Ok(())
-    }
-
     pub fn serialize_into_vec(&self, result: &mut Vec<u8>) {
         result.extend_from_slice(&u32::try_from(self.table.len()).unwrap().to_le_bytes());
         for &x in &self.table {
             result.extend_from_slice(&x.to_le_bytes());
         }
         result.extend_from_slice(&self.alphabet_size.to_le_bytes());
-    }
-
-    #[cfg(feature = "std")]
-    pub unsafe fn deserialize_unchecked<R>(mut rdr: R) -> io::Result<Self>
-    where
-        R: Read,
-    {
-        let mut len_array = [0; 4];
-        rdr.read_exact(&mut len_array)?;
-        let len = u32::from_le_bytes(len_array) as usize;
-        let mut table = Vec::with_capacity(len);
-        for _ in 0..len {
-            let mut x = [0; 4];
-            rdr.read_exact(&mut x)?;
-            table.push(u32::from_le_bytes(x));
-        }
-        let mut alphabet_size_array = [0; 4];
-        rdr.read_exact(&mut alphabet_size_array)?;
-        let alphabet_size = u32::from_le_bytes(len_array);
-        Ok(Self {
-            table,
-            alphabet_size,
-        })
     }
 
     pub unsafe fn deserialize_from_slice_unchecked(mut source: &[u8]) -> (Self, &[u8]) {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,9 +5,6 @@ use core::result;
 use alloc::fmt;
 use alloc::string::String;
 
-#[cfg(feature = "std")]
-use std::error::Error;
-
 /// Errors in daachorse.
 #[derive(Debug)]
 pub enum DaachorseError {
@@ -30,9 +27,6 @@ impl fmt::Display for DaachorseError {
         }
     }
 }
-
-#[cfg(feature = "std")]
-impl Error for DaachorseError {}
 
 impl DaachorseError {
     pub(crate) const fn invalid_argument(arg: &'static str, op: &'static str, value: u32) -> Self {
@@ -71,9 +65,6 @@ impl fmt::Display for InvalidArgumentError {
     }
 }
 
-#[cfg(feature = "std")]
-impl Error for InvalidArgumentError {}
-
 /// Error used when some patterns are duplicated.
 #[derive(Debug)]
 pub struct DuplicatePatternError {
@@ -86,9 +77,6 @@ impl fmt::Display for DuplicatePatternError {
         write!(f, "DuplicatePatternError: {}", self.pattern)
     }
 }
-
-#[cfg(feature = "std")]
-impl Error for DuplicatePatternError {}
 
 /// Error used when the scale of the automaton exceeds the expected one.
 #[derive(Debug)]
@@ -109,9 +97,6 @@ impl fmt::Display for AutomatonScaleError {
         )
     }
 }
-
-#[cfg(feature = "std")]
-impl Error for AutomatonScaleError {}
 
 /// A specialized Result type for Daachorse.
 pub type Result<T, E = DaachorseError> = result::Result<T, E>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,7 +175,10 @@
 
 #![deny(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
+
+#[cfg(not(feature = "alloc"))]
+compile_error!("`alloc` feature is currently required to build this crate");
 
 #[cfg(target_pointer_width = "16")]
 compile_error!("`target_pointer_width` must be larger than or equal to 32");


### PR DESCRIPTION
This PR removed IO functions for std::io, fully eliminating std dependencies from daachorse.
This modification disables to save/load the data structure via file streams, although the benefits will be significant:

 - Codes are simplified.
 - No need to care about invalid file streams.
