### PR TITLE
Replace as_conversions to try_from()

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,6 +66,7 @@ jobs:
             -W clippy::unnecessary-wraps
             -W clippy::unreadable-literal
             -W clippy::unused-self
+            -W clippy::as-conversions
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,18 +55,19 @@ jobs:
           args: >
             --all -- -D warnings
             -W clippy::nursery
+            -W clippy::as_conversions
             -W clippy::cast_lossless
             -W clippy::cast_possible_truncation
             -W clippy::cast_possible_wrap
-            -W clippy::cloned-instead-of-copied
-            -W clippy::must_use_candidate
+            -W clippy::cloned_instead_of_copied
             -W clippy::map_unwrap_or
-            -W clippy::redundant-closure-for-method-calls
-            -W clippy::semicolon-if-nothing-returned
-            -W clippy::unnecessary-wraps
-            -W clippy::unreadable-literal
-            -W clippy::unused-self
-            -W clippy::as-conversions
+            -W clippy::missing_panics_doc
+            -W clippy::must_use_candidate
+            -W clippy::redundant_closure_for_method-calls
+            -W clippy::semicolon_if_nothing_returned
+            -W clippy::unnecessary_wraps
+            -W clippy::unreadable_literal
+            -W clippy::unused_self
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1

--- a/bench/src/memory.rs
+++ b/bench/src/memory.rs
@@ -62,7 +62,7 @@ fn show_memory_stats(patterns: &[String]) {
                 .iter()
                 .cloned()
                 .enumerate()
-                .map(|(i, pattern)| (pattern, i as u64)),
+                .map(|(i, pattern)| (pattern, u64::try_from(i).unwrap())),
         )
         .unwrap();
         format_memory("fst", fst.as_bytes().len());
@@ -81,6 +81,7 @@ fn show_memory_stats(patterns: &[String]) {
     }
 }
 
+#[allow(clippy::as_conversions)]
 fn format_memory(title: &str, bytes: usize) {
     println!(
         "{}: {} bytes, {:.3} MiB",

--- a/src/build_helper.rs
+++ b/src/build_helper.rs
@@ -4,6 +4,7 @@ use core::ops::Range;
 use alloc::vec::Vec;
 
 use crate::errors::{DaachorseError, Result};
+use crate::utils::FromU32;
 
 /// Helper class in double-array construction to maintain indices of vacant elements and
 /// unused BASE values.
@@ -30,7 +31,7 @@ impl BuildHelper {
         let capacity = block_len.checked_mul(num_free_blocks).ok_or_else(|| {
             DaachorseError::automaton_scale("block_len * num_free_blocks", u32::MAX)
         })?;
-        let capacity = usize::try_from(capacity).unwrap();
+        let capacity = usize::from_u32(capacity);
         assert_ne!(capacity, 0);
 
         Ok(Self {
@@ -202,7 +203,7 @@ impl BuildHelper {
     #[inline(always)]
     fn offset(&self, idx: u32) -> usize {
         assert!(self.active_index_range().contains(&idx));
-        usize::try_from(idx % self.capacity()).unwrap()
+        usize::from_u32(idx % self.capacity())
     }
 }
 

--- a/src/bytewise.rs
+++ b/src/bytewise.rs
@@ -593,7 +593,7 @@ impl DoubleArrayAhoCorasick {
         for output in &self.outputs {
             wtr.write_all(&output.serialize())?;
         }
-        wtr.write_all(&[self.match_kind.into()])?;
+        wtr.write_all(&[u8::from(self.match_kind)])?;
         wtr.write_all(&u32::try_from(self.num_states).unwrap().to_le_bytes())?;
         Ok(())
     }
@@ -625,7 +625,7 @@ impl DoubleArrayAhoCorasick {
         for output in &self.outputs {
             result.extend_from_slice(&output.serialize());
         }
-        result.push(self.match_kind.into());
+        result.push(u8::from(self.match_kind));
         result.extend_from_slice(&u32::try_from(self.num_states).unwrap().to_le_bytes());
         result
     }
@@ -763,18 +763,16 @@ impl DoubleArrayAhoCorasick {
     /// ```
     #[must_use]
     pub unsafe fn deserialize_from_slice_unchecked(mut source: &[u8]) -> (Self, &[u8]) {
-        let states_len = u32::from_le_bytes(source[0..4].try_into().unwrap())
-            .try_into()
-            .unwrap();
+        let states_len =
+            usize::try_from(u32::from_le_bytes(source[0..4].try_into().unwrap())).unwrap();
         source = &source[4..];
         let mut states = Vec::with_capacity(states_len);
         for _ in 0..states_len {
             states.push(State::deserialize(source[0..12].try_into().unwrap()));
             source = &source[12..];
         }
-        let outputs_len = u32::from_le_bytes(source[0..4].try_into().unwrap())
-            .try_into()
-            .unwrap();
+        let outputs_len =
+            usize::try_from(u32::from_le_bytes(source[0..4].try_into().unwrap())).unwrap();
         source = &source[4..];
         let mut outputs = Vec::with_capacity(outputs_len);
         for _ in 0..outputs_len {

--- a/src/bytewise.rs
+++ b/src/bytewise.rs
@@ -11,6 +11,7 @@ use alloc::vec::Vec;
 use crate::build_helper::BuildHelper;
 use crate::errors::{DaachorseError, Result};
 use crate::intpack::{U24nU8, U24};
+use crate::utils::FromU32;
 use crate::{MatchKind, Output};
 pub use builder::DoubleArrayAhoCorasickBuilder;
 use iter::{
@@ -53,7 +54,7 @@ pub struct DoubleArrayAhoCorasick {
     states: Vec<State>,
     outputs: Vec<Output>,
     match_kind: MatchKind,
-    num_states: usize,
+    num_states: u32,
 }
 
 impl DoubleArrayAhoCorasick {
@@ -551,8 +552,8 @@ impl DoubleArrayAhoCorasick {
     /// assert_eq!(pma.num_states(), 6);
     /// ```
     #[must_use]
-    pub const fn num_states(&self) -> usize {
-        self.num_states
+    pub fn num_states(&self) -> usize {
+        usize::from_u32(self.num_states)
     }
 
     /// Serializes the automaton into a [`Vec`].
@@ -566,6 +567,8 @@ impl DoubleArrayAhoCorasick {
     /// let pma = DoubleArrayAhoCorasick::new(patterns).unwrap();
     /// let bytes = pma.serialize();
     /// ```
+    // Both states.len() and outputs.len() are less than or equal to u32::MAX.
+    #[allow(clippy::missing_panics_doc)]
     #[must_use]
     pub fn serialize(&self) -> Vec<u8> {
         let mut result = Vec::with_capacity(
@@ -583,7 +586,7 @@ impl DoubleArrayAhoCorasick {
             result.extend_from_slice(&output.serialize());
         }
         result.push(u8::from(self.match_kind));
-        result.extend_from_slice(&u32::try_from(self.num_states).unwrap().to_le_bytes());
+        result.extend_from_slice(&self.num_states.to_le_bytes());
         result
     }
 
@@ -630,25 +633,32 @@ impl DoubleArrayAhoCorasick {
     /// ```
     #[must_use]
     pub unsafe fn deserialize_unchecked(mut source: &[u8]) -> (Self, &[u8]) {
-        let states_len = u32::from_le_bytes(source[0..4].try_into().unwrap()) as usize;
+        let states_len = usize::from_u32(u32::from_le_bytes(
+            source[0..4].try_into().unwrap_unchecked(),
+        ));
         source = &source[4..];
         let mut states = Vec::with_capacity(states_len);
         for _ in 0..states_len {
-            states.push(State::deserialize(source[0..12].try_into().unwrap()));
+            states.push(State::deserialize(
+                source[0..12].try_into().unwrap_unchecked(),
+            ));
             source = &source[12..];
         }
-        let outputs_len =
-            usize::try_from(u32::from_le_bytes(source[0..4].try_into().unwrap())).unwrap();
+        let outputs_len = usize::from_u32(u32::from_le_bytes(
+            source[0..4].try_into().unwrap_unchecked(),
+        ));
         source = &source[4..];
         let mut outputs = Vec::with_capacity(outputs_len);
         for _ in 0..outputs_len {
-            outputs.push(Output::deserialize(source[0..12].try_into().unwrap()));
+            outputs.push(Output::deserialize(
+                source[0..12].try_into().unwrap_unchecked(),
+            ));
             source = &source[12..];
         }
 
         let match_kind = MatchKind::from(source[0]);
-        let num_states_array: [u8; 4] = source[1..5].try_into().unwrap();
-        let num_states = usize::try_from(u32::from_le_bytes(num_states_array)).unwrap();
+        let num_states_array: [u8; 4] = source[1..5].try_into().unwrap_unchecked();
+        let num_states = u32::from_le_bytes(num_states_array);
 
         (
             Self {
@@ -670,16 +680,12 @@ impl DoubleArrayAhoCorasick {
         //  - states.len() is 256 * k for some integer k, and
         //  - base() returns smaller than states.len() when it is Some.
         self.states
-            .get_unchecked(usize::try_from(state_id).unwrap())
+            .get_unchecked(usize::from_u32(state_id))
             .base()
             .and_then(|base| {
                 let child_idx = base.get() ^ u32::from(c);
-                Some(child_idx).filter(|&x| {
-                    self.states
-                        .get_unchecked(usize::try_from(x).unwrap())
-                        .check()
-                        == c
-                })
+                Some(child_idx)
+                    .filter(|&x| self.states.get_unchecked(usize::from_u32(x)).check() == c)
             })
     }
 
@@ -697,10 +703,7 @@ impl DoubleArrayAhoCorasick {
             if state_id == ROOT_STATE_IDX {
                 return ROOT_STATE_IDX;
             }
-            state_id = self
-                .states
-                .get_unchecked(usize::try_from(state_id).unwrap())
-                .fail();
+            state_id = self.states.get_unchecked(usize::from_u32(state_id)).fail();
         }
     }
 
@@ -718,10 +721,7 @@ impl DoubleArrayAhoCorasick {
             if state_id == ROOT_STATE_IDX {
                 return ROOT_STATE_IDX;
             }
-            let fail_id = self
-                .states
-                .get_unchecked(usize::try_from(state_id).unwrap())
-                .fail();
+            let fail_id = self.states.get_unchecked(usize::from_u32(state_id)).fail();
             if fail_id == DEAD_STATE_IDX {
                 return ROOT_STATE_IDX;
             }

--- a/src/bytewise/iter.rs
+++ b/src/bytewise/iter.rs
@@ -7,6 +7,7 @@ use crate::bytewise::DoubleArrayAhoCorasick;
 use crate::Match;
 
 use crate::bytewise::ROOT_STATE_IDX;
+use crate::utils::FromU32;
 
 /// Iterator for some struct that implements [`AsRef<[u8]>`].
 #[doc(hidden)]
@@ -61,7 +62,7 @@ where
             if let Some(output_pos) = unsafe {
                 self.pma
                     .states
-                    .get_unchecked(usize::try_from(state_id).unwrap())
+                    .get_unchecked(usize::from_u32(state_id))
                     .output_pos()
             } {
                 // output_pos is always smaller than self.pma.outputs.len() because
@@ -69,12 +70,12 @@ where
                 let out = unsafe {
                     self.pma
                         .outputs
-                        .get_unchecked(usize::try_from(output_pos.get()).unwrap())
+                        .get_unchecked(usize::from_u32(output_pos.get()))
                 };
                 return Some(Match {
-                    length: usize::try_from(out.length()).unwrap(),
+                    length: usize::from_u32(out.length()),
                     end: pos + 1,
-                    value: usize::try_from(out.value()).unwrap(),
+                    value: usize::from_u32(out.value()),
                 });
             }
         }
@@ -105,13 +106,13 @@ where
             let out = unsafe {
                 self.pma
                     .outputs
-                    .get_unchecked(usize::try_from(output_pos.get()).unwrap())
+                    .get_unchecked(usize::from_u32(output_pos.get()))
             };
             self.output_pos = out.parent();
             return Some(Match {
-                length: usize::try_from(out.length()).unwrap(),
+                length: usize::from_u32(out.length()),
                 end: self.pos,
-                value: usize::try_from(out.value()).unwrap(),
+                value: usize::from_u32(out.value()),
             });
         }
         for (pos, c) in self.haystack.by_ref() {
@@ -121,7 +122,7 @@ where
             if let Some(output_pos) = unsafe {
                 self.pma
                     .states
-                    .get_unchecked(usize::try_from(self.state_id).unwrap())
+                    .get_unchecked(usize::from_u32(self.state_id))
                     .output_pos()
             } {
                 self.pos = pos + 1;
@@ -130,13 +131,13 @@ where
                 let out = unsafe {
                     self.pma
                         .outputs
-                        .get_unchecked(usize::try_from(output_pos.get()).unwrap())
+                        .get_unchecked(usize::from_u32(output_pos.get()))
                 };
                 self.output_pos = out.parent();
                 return Some(Match {
-                    length: usize::try_from(out.length()).unwrap(),
+                    length: usize::from_u32(out.length()),
                     end: self.pos,
-                    value: usize::try_from(out.value()).unwrap(),
+                    value: usize::from_u32(out.value()),
                 });
             }
         }
@@ -166,7 +167,7 @@ where
             if let Some(output_pos) = unsafe {
                 self.pma
                     .states
-                    .get_unchecked(usize::try_from(self.state_id).unwrap())
+                    .get_unchecked(usize::from_u32(self.state_id))
                     .output_pos()
             } {
                 // output_pos is always smaller than self.pma.outputs.len() because
@@ -174,12 +175,12 @@ where
                 let out = unsafe {
                     self.pma
                         .outputs
-                        .get_unchecked(usize::try_from(output_pos.get()).unwrap())
+                        .get_unchecked(usize::from_u32(output_pos.get()))
                 };
                 return Some(Match {
-                    length: usize::try_from(out.length()).unwrap(),
+                    length: usize::from_u32(out.length()),
                     end: pos + 1,
-                    value: usize::try_from(out.value()).unwrap(),
+                    value: usize::from_u32(out.value()),
                 });
             }
         }
@@ -220,12 +221,12 @@ where
                     let out = unsafe {
                         self.pma
                             .outputs
-                            .get_unchecked(usize::try_from(output_pos.get()).unwrap())
+                            .get_unchecked(usize::from_u32(output_pos.get()))
                     };
                     return Some(Match {
-                        length: usize::try_from(out.length()).unwrap(),
+                        length: usize::from_u32(out.length()),
                         end: self.pos,
-                        value: usize::try_from(out.value()).unwrap(),
+                        value: usize::from_u32(out.value()),
                     });
                 }
             // state_id is always smaller than self.pma.states.len() because
@@ -233,7 +234,7 @@ where
             } else if let Some(output_pos) = unsafe {
                 self.pma
                     .states
-                    .get_unchecked(usize::try_from(state_id).unwrap())
+                    .get_unchecked(usize::from_u32(state_id))
                     .output_pos()
             } {
                 last_output_pos.replace(output_pos);
@@ -247,12 +248,12 @@ where
             let out = unsafe {
                 self.pma
                     .outputs
-                    .get_unchecked(usize::try_from(output_pos.get()).unwrap())
+                    .get_unchecked(usize::from_u32(output_pos.get()))
             };
             Match {
-                length: usize::try_from(out.length()).unwrap(),
+                length: usize::from_u32(out.length()),
                 end: self.pos,
-                value: usize::try_from(out.value()).unwrap(),
+                value: usize::from_u32(out.value()),
             }
         })
     }

--- a/src/bytewise/iter.rs
+++ b/src/bytewise/iter.rs
@@ -61,16 +61,20 @@ where
             if let Some(output_pos) = unsafe {
                 self.pma
                     .states
-                    .get_unchecked(state_id as usize)
+                    .get_unchecked(usize::try_from(state_id).unwrap())
                     .output_pos()
             } {
                 // output_pos is always smaller than self.pma.outputs.len() because
                 // State::output_pos() ensures to return such a value when it is Some.
-                let out = unsafe { self.pma.outputs.get_unchecked(output_pos.get() as usize) };
+                let out = unsafe {
+                    self.pma
+                        .outputs
+                        .get_unchecked(usize::try_from(output_pos.get()).unwrap())
+                };
                 return Some(Match {
-                    length: out.length() as usize,
+                    length: usize::try_from(out.length()).unwrap(),
                     end: pos + 1,
-                    value: out.value() as usize,
+                    value: usize::try_from(out.value()).unwrap(),
                 });
             }
         }
@@ -98,12 +102,16 @@ where
         if let Some(output_pos) = self.output_pos {
             // output_pos.get() is always smaller than self.pma.outputs.len() because
             // Output::parent() ensures to return such a value when it is Some.
-            let out = unsafe { self.pma.outputs.get_unchecked(output_pos.get() as usize) };
+            let out = unsafe {
+                self.pma
+                    .outputs
+                    .get_unchecked(usize::try_from(output_pos.get()).unwrap())
+            };
             self.output_pos = out.parent();
             return Some(Match {
-                length: out.length() as usize,
+                length: usize::try_from(out.length()).unwrap(),
                 end: self.pos,
-                value: out.value() as usize,
+                value: usize::try_from(out.value()).unwrap(),
             });
         }
         for (pos, c) in self.haystack.by_ref() {
@@ -113,18 +121,22 @@ where
             if let Some(output_pos) = unsafe {
                 self.pma
                     .states
-                    .get_unchecked(self.state_id as usize)
+                    .get_unchecked(usize::try_from(self.state_id).unwrap())
                     .output_pos()
             } {
                 self.pos = pos + 1;
                 // output_pos.get() is always smaller than self.pma.outputs.len() because
                 // State::output_pos() ensures to return such a value when it is Some.
-                let out = unsafe { self.pma.outputs.get_unchecked(output_pos.get() as usize) };
+                let out = unsafe {
+                    self.pma
+                        .outputs
+                        .get_unchecked(usize::try_from(output_pos.get()).unwrap())
+                };
                 self.output_pos = out.parent();
                 return Some(Match {
-                    length: out.length() as usize,
+                    length: usize::try_from(out.length()).unwrap(),
                     end: self.pos,
-                    value: out.value() as usize,
+                    value: usize::try_from(out.value()).unwrap(),
                 });
             }
         }
@@ -154,16 +166,20 @@ where
             if let Some(output_pos) = unsafe {
                 self.pma
                     .states
-                    .get_unchecked(self.state_id as usize)
+                    .get_unchecked(usize::try_from(self.state_id).unwrap())
                     .output_pos()
             } {
                 // output_pos is always smaller than self.pma.outputs.len() because
                 // State::output_pos() ensures to return such a value when it is Some.
-                let out = unsafe { self.pma.outputs.get_unchecked(output_pos.get() as usize) };
+                let out = unsafe {
+                    self.pma
+                        .outputs
+                        .get_unchecked(usize::try_from(output_pos.get()).unwrap())
+                };
                 return Some(Match {
-                    length: out.length() as usize,
+                    length: usize::try_from(out.length()).unwrap(),
                     end: pos + 1,
-                    value: out.value() as usize,
+                    value: usize::try_from(out.value()).unwrap(),
                 });
             }
         }
@@ -201,11 +217,15 @@ where
                 if let Some(output_pos) = last_output_pos {
                     // last_output_pos is always smaller than self.pma.outputs.len() because
                     // State::output_pos() ensures to return such a value when it is Some.
-                    let out = unsafe { self.pma.outputs.get_unchecked(output_pos.get() as usize) };
+                    let out = unsafe {
+                        self.pma
+                            .outputs
+                            .get_unchecked(usize::try_from(output_pos.get()).unwrap())
+                    };
                     return Some(Match {
-                        length: out.length() as usize,
+                        length: usize::try_from(out.length()).unwrap(),
                         end: self.pos,
-                        value: out.value() as usize,
+                        value: usize::try_from(out.value()).unwrap(),
                     });
                 }
             // state_id is always smaller than self.pma.states.len() because
@@ -213,7 +233,7 @@ where
             } else if let Some(output_pos) = unsafe {
                 self.pma
                     .states
-                    .get_unchecked(state_id as usize)
+                    .get_unchecked(usize::try_from(state_id).unwrap())
                     .output_pos()
             } {
                 last_output_pos.replace(output_pos);
@@ -224,11 +244,15 @@ where
         last_output_pos.map(|output_pos| {
             // last_output_pos is always smaller than self.pma.outputs.len() because
             // State::output_pos() ensures to return such a value when it is Some.
-            let out = unsafe { self.pma.outputs.get_unchecked(output_pos.get() as usize) };
+            let out = unsafe {
+                self.pma
+                    .outputs
+                    .get_unchecked(usize::try_from(output_pos.get()).unwrap())
+            };
             Match {
-                length: out.length() as usize,
+                length: usize::try_from(out.length()).unwrap(),
                 end: self.pos,
-                value: out.value() as usize,
+                value: usize::try_from(out.value()).unwrap(),
             }
         })
     }

--- a/src/charwise.rs
+++ b/src/charwise.rs
@@ -628,7 +628,7 @@ impl CharwiseDoubleArrayAhoCorasick {
         for output in &self.outputs {
             wtr.write_all(&output.serialize())?;
         }
-        wtr.write_all(&[self.match_kind.into()])?;
+        wtr.write_all(&[u8::from(self.match_kind)])?;
         wtr.write_all(&u32::try_from(self.num_states).unwrap().to_le_bytes())?;
         Ok(())
     }
@@ -662,7 +662,7 @@ impl CharwiseDoubleArrayAhoCorasick {
         for output in &self.outputs {
             result.extend_from_slice(&output.serialize());
         }
-        result.push(self.match_kind.into());
+        result.push(u8::from(self.match_kind));
         result.extend_from_slice(&u32::try_from(self.num_states).unwrap().to_le_bytes());
         result
     }
@@ -804,9 +804,8 @@ impl CharwiseDoubleArrayAhoCorasick {
     /// ```
     #[must_use]
     pub unsafe fn deserialize_from_slice_unchecked(mut source: &[u8]) -> (Self, &[u8]) {
-        let states_len = u32::from_le_bytes(source[0..4].try_into().unwrap())
-            .try_into()
-            .unwrap();
+        let states_len =
+            usize::try_from(u32::from_le_bytes(source[0..4].try_into().unwrap())).unwrap();
         source = &source[4..];
         let mut states = Vec::with_capacity(states_len);
         for _ in 0..states_len {
@@ -816,9 +815,8 @@ impl CharwiseDoubleArrayAhoCorasick {
 
         let (mapper, mut source) = CodeMapper::deserialize_from_slice_unchecked(source);
 
-        let outputs_len = u32::from_le_bytes(source[0..4].try_into().unwrap())
-            .try_into()
-            .unwrap();
+        let outputs_len =
+            usize::try_from(u32::from_le_bytes(source[0..4].try_into().unwrap())).unwrap();
         source = &source[4..];
         let mut outputs = Vec::with_capacity(outputs_len);
         for _ in 0..outputs_len {

--- a/src/charwise/builder.rs
+++ b/src/charwise/builder.rs
@@ -136,7 +136,7 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
         let patvals = patterns
             .into_iter()
             .enumerate()
-            .map(|(i, p)| (p, i.try_into().unwrap_or(0)));
+            .map(|(i, p)| (p, u32::try_from(i).unwrap_or(0)));
         self.build_with_values(patvals)
     }
 
@@ -234,7 +234,7 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
         let mut helper = self.init_array()?;
 
         let mut state_id_map = vec![DEAD_STATE_IDX; nfa.states.len()];
-        state_id_map[ROOT_STATE_ID as usize] = ROOT_STATE_IDX;
+        state_id_map[usize::try_from(ROOT_STATE_ID).unwrap()] = ROOT_STATE_IDX;
 
         // Arranges base & check values
         let mut stack = vec![ROOT_STATE_ID];
@@ -242,9 +242,9 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
 
         while let Some(state_id) = stack.pop() {
             debug_assert_ne!(state_id, DEAD_STATE_ID);
-            let state = &nfa.states[state_id as usize];
+            let state = &nfa.states[usize::try_from(state_id).unwrap()];
 
-            let state_idx = state_id_map[state_id as usize];
+            let state_idx = state_id_map[usize::try_from(state_id).unwrap()];
             debug_assert_ne!(state_idx, DEAD_STATE_IDX);
 
             let s = &state.borrow();
@@ -259,28 +259,28 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
             mapped.sort_by(|(c1, _), (c2, _)| c1.cmp(c2));
 
             let base = self.find_base(&mapped, &helper);
-            if self.states.len() <= base.get() as usize {
+            if self.states.len() <= usize::try_from(base.get()).unwrap() {
                 self.extend_array(&mut helper)?;
             }
 
             for &(c, child_id) in &mapped {
                 let child_idx = base.get() ^ c;
                 helper.use_index(child_idx);
-                self.states[child_idx as usize].set_check(state_idx);
-                state_id_map[child_id as usize] = child_idx;
+                self.states[usize::try_from(child_idx).unwrap()].set_check(state_idx);
+                state_id_map[usize::try_from(child_id).unwrap()] = child_idx;
                 stack.push(child_id);
             }
-            self.states[state_idx as usize].set_base(base);
+            self.states[usize::try_from(state_idx).unwrap()].set_base(base);
         }
 
         // Sets fail & output_pos values
         for (i, state) in nfa.states.iter().enumerate() {
-            if i == DEAD_STATE_ID as usize {
+            if i == usize::try_from(DEAD_STATE_ID).unwrap() {
                 continue;
             }
 
-            let idx = state_id_map[i] as usize;
-            debug_assert_ne!(idx, DEAD_STATE_IDX as usize);
+            let idx = usize::try_from(state_id_map[i]).unwrap();
+            debug_assert_ne!(idx, usize::try_from(DEAD_STATE_IDX).unwrap());
 
             let s = &state.borrow();
             self.states[idx].set_output_pos(s.output_pos);
@@ -289,7 +289,7 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
             if fail_id == DEAD_STATE_ID {
                 self.states[idx].set_fail(DEAD_STATE_IDX);
             } else {
-                let fail_idx = state_id_map[fail_id as usize];
+                let fail_idx = state_id_map[usize::try_from(fail_id).unwrap()];
                 debug_assert_ne!(fail_idx, DEAD_STATE_IDX);
                 self.states[idx].set_fail(fail_idx);
             }

--- a/src/charwise/iter.rs
+++ b/src/charwise/iter.rs
@@ -137,12 +137,16 @@ where
         if let Some(output_pos) = self.output_pos {
             // output_pos.get() is always smaller than self.pma.outputs.len() because
             // Output::parent() ensures to return such a value when it is Some.
-            let out = unsafe { self.pma.outputs.get_unchecked(output_pos.get() as usize) };
+            let out = unsafe {
+                self.pma
+                    .outputs
+                    .get_unchecked(usize::try_from(output_pos.get()).unwrap())
+            };
             self.output_pos = out.parent();
             return Some(Match {
-                length: out.length() as usize,
+                length: usize::try_from(out.length()).unwrap(),
                 end: self.pos,
-                value: out.value() as usize,
+                value: usize::try_from(out.value()).unwrap(),
             });
         }
 
@@ -155,17 +159,21 @@ where
             if let Some(output_pos) = unsafe {
                 self.pma
                     .states
-                    .get_unchecked(self.state_id as usize)
+                    .get_unchecked(usize::try_from(self.state_id).unwrap())
                     .output_pos()
             } {
                 // output_pos.get() is always smaller than self.pma.outputs.len() because
                 // State::output_pos() ensures to return such a value when it is Some.
-                let out = unsafe { self.pma.outputs.get_unchecked(output_pos.get() as usize) };
+                let out = unsafe {
+                    self.pma
+                        .outputs
+                        .get_unchecked(usize::try_from(output_pos.get()).unwrap())
+                };
                 self.output_pos = out.parent();
                 return Some(Match {
-                    length: out.length() as usize,
+                    length: usize::try_from(out.length()).unwrap(),
                     end: pos,
-                    value: out.value() as usize,
+                    value: usize::try_from(out.value()).unwrap(),
                 });
             }
         }
@@ -189,16 +197,20 @@ where
             if let Some(output_pos) = unsafe {
                 self.pma
                     .states
-                    .get_unchecked(state_id as usize)
+                    .get_unchecked(usize::try_from(state_id).unwrap())
                     .output_pos()
             } {
                 // output_pos is always smaller than self.pma.outputs.len() because
                 // State::output_pos() ensures to return such a value when it is Some.
-                let out = unsafe { self.pma.outputs.get_unchecked(output_pos.get() as usize) };
+                let out = unsafe {
+                    self.pma
+                        .outputs
+                        .get_unchecked(usize::try_from(output_pos.get()).unwrap())
+                };
                 return Some(Match {
-                    length: out.length() as usize,
+                    length: usize::try_from(out.length()).unwrap(),
                     end: pos,
-                    value: out.value() as usize,
+                    value: usize::try_from(out.value()).unwrap(),
                 });
             }
         }
@@ -221,16 +233,20 @@ where
             if let Some(output_pos) = unsafe {
                 self.pma
                     .states
-                    .get_unchecked(self.state_id as usize)
+                    .get_unchecked(usize::try_from(self.state_id).unwrap())
                     .output_pos()
             } {
                 // output_pos is always smaller than self.pma.outputs.len() because
                 // State::output_pos() ensures to return such a value when it is Some.
-                let out = unsafe { self.pma.outputs.get_unchecked(output_pos.get() as usize) };
+                let out = unsafe {
+                    self.pma
+                        .outputs
+                        .get_unchecked(usize::try_from(output_pos.get()).unwrap())
+                };
                 return Some(Match {
-                    length: out.length() as usize,
+                    length: usize::try_from(out.length()).unwrap(),
                     end: pos,
-                    value: out.value() as usize,
+                    value: usize::try_from(out.value()).unwrap(),
                 });
             }
         }
@@ -260,11 +276,15 @@ where
                 if let Some(output_pos) = last_output_pos {
                     // last_output_pos is always smaller than self.pma.outputs.len() because
                     // State::output_pos() ensures to return such a value when it is Some.
-                    let out = unsafe { self.pma.outputs.get_unchecked(output_pos.get() as usize) };
+                    let out = unsafe {
+                        self.pma
+                            .outputs
+                            .get_unchecked(usize::try_from(output_pos.get()).unwrap())
+                    };
                     return Some(Match {
-                        length: out.length() as usize,
+                        length: usize::try_from(out.length()).unwrap(),
                         end: self.pos,
-                        value: out.value() as usize,
+                        value: usize::try_from(out.value()).unwrap(),
                     });
                 }
             // state_id is always smaller than self.pma.states.len() because
@@ -272,7 +292,7 @@ where
             } else if let Some(output_pos) = unsafe {
                 self.pma
                     .states
-                    .get_unchecked(state_id as usize)
+                    .get_unchecked(usize::try_from(state_id).unwrap())
                     .output_pos()
             } {
                 last_output_pos.replace(output_pos);
@@ -284,11 +304,15 @@ where
         last_output_pos.map(|output_pos| {
             // last_output_pos is always smaller than self.pma.outputs.len() because
             // State::output_pos() ensures to return such a value when it is Some.
-            let out = unsafe { self.pma.outputs.get_unchecked(output_pos.get() as usize) };
+            let out = unsafe {
+                self.pma
+                    .outputs
+                    .get_unchecked(usize::try_from(output_pos.get()).unwrap())
+            };
             Match {
-                length: out.length() as usize,
+                length: usize::try_from(out.length()).unwrap(),
                 end: self.pos,
-                value: out.value() as usize,
+                value: usize::try_from(out.value()).unwrap(),
             }
         })
     }

--- a/src/charwise/iter.rs
+++ b/src/charwise/iter.rs
@@ -6,6 +6,7 @@ use core::num::NonZeroU32;
 use crate::charwise::CharwiseDoubleArrayAhoCorasick;
 
 use crate::charwise::ROOT_STATE_IDX;
+use crate::utils::FromU32;
 use crate::Match;
 
 /// Iterator for some struct that implements [`AsRef<str>`].
@@ -140,13 +141,13 @@ where
             let out = unsafe {
                 self.pma
                     .outputs
-                    .get_unchecked(usize::try_from(output_pos.get()).unwrap())
+                    .get_unchecked(usize::from_u32(output_pos.get()))
             };
             self.output_pos = out.parent();
             return Some(Match {
-                length: usize::try_from(out.length()).unwrap(),
+                length: usize::from_u32(out.length()),
                 end: self.pos,
-                value: usize::try_from(out.value()).unwrap(),
+                value: usize::from_u32(out.value()),
             });
         }
 
@@ -159,7 +160,7 @@ where
             if let Some(output_pos) = unsafe {
                 self.pma
                     .states
-                    .get_unchecked(usize::try_from(self.state_id).unwrap())
+                    .get_unchecked(usize::from_u32(self.state_id))
                     .output_pos()
             } {
                 // output_pos.get() is always smaller than self.pma.outputs.len() because
@@ -167,13 +168,13 @@ where
                 let out = unsafe {
                     self.pma
                         .outputs
-                        .get_unchecked(usize::try_from(output_pos.get()).unwrap())
+                        .get_unchecked(usize::from_u32(output_pos.get()))
                 };
                 self.output_pos = out.parent();
                 return Some(Match {
-                    length: usize::try_from(out.length()).unwrap(),
+                    length: usize::from_u32(out.length()),
                     end: pos,
-                    value: usize::try_from(out.value()).unwrap(),
+                    value: usize::from_u32(out.value()),
                 });
             }
         }
@@ -197,7 +198,7 @@ where
             if let Some(output_pos) = unsafe {
                 self.pma
                     .states
-                    .get_unchecked(usize::try_from(state_id).unwrap())
+                    .get_unchecked(usize::from_u32(state_id))
                     .output_pos()
             } {
                 // output_pos is always smaller than self.pma.outputs.len() because
@@ -205,12 +206,12 @@ where
                 let out = unsafe {
                     self.pma
                         .outputs
-                        .get_unchecked(usize::try_from(output_pos.get()).unwrap())
+                        .get_unchecked(usize::from_u32(output_pos.get()))
                 };
                 return Some(Match {
-                    length: usize::try_from(out.length()).unwrap(),
+                    length: usize::from_u32(out.length()),
                     end: pos,
-                    value: usize::try_from(out.value()).unwrap(),
+                    value: usize::from_u32(out.value()),
                 });
             }
         }
@@ -233,7 +234,7 @@ where
             if let Some(output_pos) = unsafe {
                 self.pma
                     .states
-                    .get_unchecked(usize::try_from(self.state_id).unwrap())
+                    .get_unchecked(usize::from_u32(self.state_id))
                     .output_pos()
             } {
                 // output_pos is always smaller than self.pma.outputs.len() because
@@ -241,12 +242,12 @@ where
                 let out = unsafe {
                     self.pma
                         .outputs
-                        .get_unchecked(usize::try_from(output_pos.get()).unwrap())
+                        .get_unchecked(usize::from_u32(output_pos.get()))
                 };
                 return Some(Match {
-                    length: usize::try_from(out.length()).unwrap(),
+                    length: usize::from_u32(out.length()),
                     end: pos,
-                    value: usize::try_from(out.value()).unwrap(),
+                    value: usize::from_u32(out.value()),
                 });
             }
         }
@@ -279,12 +280,12 @@ where
                     let out = unsafe {
                         self.pma
                             .outputs
-                            .get_unchecked(usize::try_from(output_pos.get()).unwrap())
+                            .get_unchecked(usize::from_u32(output_pos.get()))
                     };
                     return Some(Match {
-                        length: usize::try_from(out.length()).unwrap(),
+                        length: usize::from_u32(out.length()),
                         end: self.pos,
-                        value: usize::try_from(out.value()).unwrap(),
+                        value: usize::from_u32(out.value()),
                     });
                 }
             // state_id is always smaller than self.pma.states.len() because
@@ -292,7 +293,7 @@ where
             } else if let Some(output_pos) = unsafe {
                 self.pma
                     .states
-                    .get_unchecked(usize::try_from(state_id).unwrap())
+                    .get_unchecked(usize::from_u32(state_id))
                     .output_pos()
             } {
                 last_output_pos.replace(output_pos);
@@ -307,12 +308,12 @@ where
             let out = unsafe {
                 self.pma
                     .outputs
-                    .get_unchecked(usize::try_from(output_pos.get()).unwrap())
+                    .get_unchecked(usize::from_u32(output_pos.get()))
             };
             Match {
-                length: usize::try_from(out.length()).unwrap(),
+                length: usize::from_u32(out.length()),
                 end: self.pos,
-                value: usize::try_from(out.value()).unwrap(),
+                value: usize::from_u32(out.value()),
             }
         })
     }

--- a/src/charwise/mapper.rs
+++ b/src/charwise/mapper.rs
@@ -102,9 +102,7 @@ impl CodeMapper {
     }
 
     pub unsafe fn deserialize_from_slice_unchecked(mut source: &[u8]) -> (Self, &[u8]) {
-        let len = u32::from_le_bytes(source[0..4].try_into().unwrap())
-            .try_into()
-            .unwrap();
+        let len = usize::try_from(u32::from_le_bytes(source[0..4].try_into().unwrap())).unwrap();
         source = &source[4..];
         let mut table = Vec::with_capacity(len);
         for _ in 0..len {

--- a/src/charwise/mapper.rs
+++ b/src/charwise/mapper.rs
@@ -24,11 +24,11 @@ impl CodeMapper {
         };
         let mut table = vec![INVALID_CODE; freqs.len()];
         for (i, &(c, _)) in sorted.iter().enumerate() {
-            table[c] = i.try_into().unwrap();
+            table[c] = u32::try_from(i).unwrap();
         }
         Self {
             table,
-            alphabet_size: sorted.len().try_into().unwrap(),
+            alphabet_size: u32::try_from(sorted.len()).unwrap(),
         }
     }
 
@@ -85,7 +85,7 @@ impl CodeMapper {
     {
         let mut len_array = [0; 4];
         rdr.read_exact(&mut len_array)?;
-        let len = u32::from_le_bytes(len_array) as usize;
+        let len = usize::try_from(u32::from_le_bytes(len_array)).unwrap();
         let mut table = Vec::with_capacity(len);
         for _ in 0..len {
             let mut x = [0; 4];
@@ -102,7 +102,9 @@ impl CodeMapper {
     }
 
     pub unsafe fn deserialize_from_slice_unchecked(mut source: &[u8]) -> (Self, &[u8]) {
-        let len = u32::from_le_bytes(source[0..4].try_into().unwrap()) as usize;
+        let len = u32::from_le_bytes(source[0..4].try_into().unwrap())
+            .try_into()
+            .unwrap();
         source = &source[4..];
         let mut table = Vec::with_capacity(len);
         for _ in 0..len {

--- a/src/charwise/mapper.rs
+++ b/src/charwise/mapper.rs
@@ -1,5 +1,7 @@
 use alloc::vec::Vec;
 
+use crate::utils::FromU32;
+
 pub const INVALID_CODE: u32 = u32::MAX;
 
 #[derive(Default, Clone, Debug, Eq, Hash, PartialEq)]
@@ -32,7 +34,7 @@ impl CodeMapper {
     #[inline(always)]
     pub fn get(&self, c: char) -> Option<u32> {
         self.table
-            .get(usize::try_from(u32::from(c)).unwrap())
+            .get(usize::from_u32(u32::from(c)))
             .copied()
             .filter(|&code| code != INVALID_CODE)
     }
@@ -63,7 +65,7 @@ impl CodeMapper {
     }
 
     pub unsafe fn deserialize_unchecked(mut source: &[u8]) -> (Self, &[u8]) {
-        let len = u32::from_le_bytes(source[0..4].try_into().unwrap()) as usize;
+        let len = usize::from_u32(u32::from_le_bytes(source[0..4].try_into().unwrap()));
         source = &source[4..];
         let mut table = Vec::with_capacity(len);
         for _ in 0..len {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -329,3 +329,13 @@ impl From<u8> for MatchKind {
         }
     }
 }
+
+impl From<MatchKind> for u8 {
+    fn from(src: MatchKind) -> Self {
+        match src {
+            MatchKind::Standard => 0,
+            MatchKind::LeftmostLongest => 1,
+            MatchKind::LeftmostFirst => 2,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,6 +192,7 @@ pub mod charwise;
 pub mod errors;
 mod intpack;
 mod nfa_builder;
+mod utils;
 
 use core::num::NonZeroU32;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,6 +5,8 @@ pub trait FromU32 {
 #[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 impl FromU32 for usize {
     fn from_u32(src: u32) -> Self {
+        // Since the pointer width is guaranteed to be 32 or 64, the following process always
+        // succeeds.
         unsafe { Self::try_from(src).unwrap_unchecked() }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,6 +4,7 @@ pub trait FromU32 {
 
 #[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
 impl FromU32 for usize {
+    #[inline(always)]
     fn from_u32(src: u32) -> Self {
         // Since the pointer width is guaranteed to be 32 or 64, the following process always
         // succeeds.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,10 @@
+pub trait FromU32 {
+    fn from_u32(src: u32) -> Self;
+}
+
+#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
+impl FromU32 for usize {
+    fn from_u32(src: u32) -> Self {
+        unsafe { Self::try_from(src).unwrap_unchecked() }
+    }
+}


### PR DESCRIPTION
Since `as` is dangerous due to possible overflow, this branch uses `try_from()` or `from_u32()` for type conversion.