### PR TITLE
Change output type to generic type

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ use daachorse::{DoubleArrayAhoCorasickBuilder, MatchKind};
 
 let patterns = vec!["ab", "a", "abcd"];
 let pma = DoubleArrayAhoCorasickBuilder::new()
-          .match_kind(MatchKind::LeftmostLongest)
-          .build(&patterns)
-          .unwrap();
+    .match_kind(MatchKind::LeftmostLongest)
+    .build(&patterns)
+    .unwrap();
 
 let mut it = pma.leftmost_find_iter("abcd");
 
@@ -139,9 +139,9 @@ use daachorse::{DoubleArrayAhoCorasickBuilder, MatchKind};
 
 let patterns = vec!["ab", "a", "abcd"];
 let pma = DoubleArrayAhoCorasickBuilder::new()
-          .match_kind(MatchKind::LeftmostFirst)
-          .build(&patterns)
-          .unwrap();
+    .match_kind(MatchKind::LeftmostFirst)
+    .build(&patterns)
+    .unwrap();
 
 let mut it = pma.leftmost_find_iter("abcd");
 

--- a/bench/benches/benchmark.rs
+++ b/bench/benches/benchmark.rs
@@ -215,11 +215,13 @@ define_find_bench!(
 
 fn add_build_benches(group: &mut BenchmarkGroup<WallTime>, patterns: &[String]) {
     group.bench_function("daachorse", |b| {
-        b.iter(|| daachorse::DoubleArrayAhoCorasick::new(patterns).unwrap());
+        b.iter(|| daachorse::DoubleArrayAhoCorasick::<usize>::new(patterns).unwrap());
     });
 
     group.bench_function("daachorse/charwise", |b| {
-        b.iter(|| daachorse::charwise::CharwiseDoubleArrayAhoCorasick::new(patterns).unwrap());
+        b.iter(|| {
+            daachorse::charwise::CharwiseDoubleArrayAhoCorasick::<usize>::new(patterns).unwrap()
+        });
     });
 
     group.bench_function("aho_corasick/nfa", |b| {
@@ -268,7 +270,7 @@ fn add_find_benches(
     haystacks: &[String],
 ) {
     group.bench_function("daachorse", |b| {
-        let pma = daachorse::DoubleArrayAhoCorasick::new(patterns).unwrap();
+        let pma = daachorse::DoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
         b.iter(|| {
             let mut sum = 0;
             for haystack in haystacks {
@@ -283,7 +285,8 @@ fn add_find_benches(
     });
 
     group.bench_function("daachorse/charwise", |b| {
-        let pma = daachorse::charwise::CharwiseDoubleArrayAhoCorasick::new(patterns).unwrap();
+        let pma =
+            daachorse::charwise::CharwiseDoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
         b.iter(|| {
             let mut sum = 0;
             for haystack in haystacks {
@@ -336,7 +339,7 @@ fn add_find_overlapping_benches(
     haystacks: &[String],
 ) {
     group.bench_function("daachorse", |b| {
-        let pma = daachorse::DoubleArrayAhoCorasick::new(patterns).unwrap();
+        let pma = daachorse::DoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
         b.iter(|| {
             let mut sum = 0;
             for haystack in haystacks {
@@ -351,7 +354,7 @@ fn add_find_overlapping_benches(
     });
 
     group.bench_function("daachorse/no_suffix", |b| {
-        let pma = daachorse::DoubleArrayAhoCorasick::new(patterns).unwrap();
+        let pma = daachorse::DoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
         b.iter(|| {
             let mut sum = 0;
             for haystack in haystacks {
@@ -366,7 +369,8 @@ fn add_find_overlapping_benches(
     });
 
     group.bench_function("daachorse/charwise", |b| {
-        let pma = daachorse::charwise::CharwiseDoubleArrayAhoCorasick::new(patterns).unwrap();
+        let pma =
+            daachorse::charwise::CharwiseDoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
         b.iter(|| {
             let mut sum = 0;
             for haystack in haystacks {
@@ -381,7 +385,8 @@ fn add_find_overlapping_benches(
     });
 
     group.bench_function("daachorse/charwise/no_suffix", |b| {
-        let pma = daachorse::charwise::CharwiseDoubleArrayAhoCorasick::new(patterns).unwrap();
+        let pma =
+            daachorse::charwise::CharwiseDoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
         b.iter(|| {
             let mut sum = 0;
             for haystack in haystacks {
@@ -486,10 +491,11 @@ fn add_find_leftmost_longest_benches(
     haystacks: &[String],
 ) {
     group.bench_function("daachorse", |b| {
-        let pma = daachorse::DoubleArrayAhoCorasickBuilder::new()
-            .match_kind(daachorse::MatchKind::LeftmostLongest)
-            .build(patterns)
-            .unwrap();
+        let pma: daachorse::DoubleArrayAhoCorasick<usize> =
+            daachorse::DoubleArrayAhoCorasickBuilder::new()
+                .match_kind(daachorse::MatchKind::LeftmostLongest)
+                .build(patterns)
+                .unwrap();
         b.iter(|| {
             let mut sum = 0;
             for haystack in haystacks {
@@ -504,10 +510,11 @@ fn add_find_leftmost_longest_benches(
     });
 
     group.bench_function("daachorse/charwise", |b| {
-        let pma = daachorse::charwise::CharwiseDoubleArrayAhoCorasickBuilder::new()
-            .match_kind(daachorse::MatchKind::LeftmostLongest)
-            .build(patterns)
-            .unwrap();
+        let pma: daachorse::CharwiseDoubleArrayAhoCorasick<usize> =
+            daachorse::charwise::CharwiseDoubleArrayAhoCorasickBuilder::new()
+                .match_kind(daachorse::MatchKind::LeftmostLongest)
+                .build(patterns)
+                .unwrap();
         b.iter(|| {
             let mut sum = 0;
             for haystack in haystacks {
@@ -563,10 +570,11 @@ fn add_find_leftmost_first_benches(
     haystacks: &[String],
 ) {
     group.bench_function("daachorse", |b| {
-        let pma = daachorse::DoubleArrayAhoCorasickBuilder::new()
-            .match_kind(daachorse::MatchKind::LeftmostFirst)
-            .build(patterns)
-            .unwrap();
+        let pma: daachorse::DoubleArrayAhoCorasick<usize> =
+            daachorse::DoubleArrayAhoCorasickBuilder::new()
+                .match_kind(daachorse::MatchKind::LeftmostFirst)
+                .build(patterns)
+                .unwrap();
         b.iter(|| {
             let mut sum = 0;
             for haystack in haystacks {
@@ -581,10 +589,11 @@ fn add_find_leftmost_first_benches(
     });
 
     group.bench_function("daachorse/charwise", |b| {
-        let pma = daachorse::charwise::CharwiseDoubleArrayAhoCorasickBuilder::new()
-            .match_kind(daachorse::MatchKind::LeftmostFirst)
-            .build(patterns)
-            .unwrap();
+        let pma: daachorse::CharwiseDoubleArrayAhoCorasick<usize> =
+            daachorse::charwise::CharwiseDoubleArrayAhoCorasickBuilder::new()
+                .match_kind(daachorse::MatchKind::LeftmostFirst)
+                .build(patterns)
+                .unwrap();
         b.iter(|| {
             let mut sum = 0;
             for haystack in haystacks {

--- a/bench/benches/benchmark.rs
+++ b/bench/benches/benchmark.rs
@@ -219,9 +219,7 @@ fn add_build_benches(group: &mut BenchmarkGroup<WallTime>, patterns: &[String]) 
     });
 
     group.bench_function("daachorse/charwise", |b| {
-        b.iter(|| {
-            daachorse::charwise::CharwiseDoubleArrayAhoCorasick::<usize>::new(patterns).unwrap()
-        });
+        b.iter(|| daachorse::CharwiseDoubleArrayAhoCorasick::<usize>::new(patterns).unwrap());
     });
 
     group.bench_function("aho_corasick/nfa", |b| {
@@ -285,8 +283,7 @@ fn add_find_benches(
     });
 
     group.bench_function("daachorse/charwise", |b| {
-        let pma =
-            daachorse::charwise::CharwiseDoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
+        let pma = daachorse::CharwiseDoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
         b.iter(|| {
             let mut sum = 0;
             for haystack in haystacks {
@@ -369,8 +366,7 @@ fn add_find_overlapping_benches(
     });
 
     group.bench_function("daachorse/charwise", |b| {
-        let pma =
-            daachorse::charwise::CharwiseDoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
+        let pma = daachorse::CharwiseDoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
         b.iter(|| {
             let mut sum = 0;
             for haystack in haystacks {
@@ -385,8 +381,7 @@ fn add_find_overlapping_benches(
     });
 
     group.bench_function("daachorse/charwise/no_suffix", |b| {
-        let pma =
-            daachorse::charwise::CharwiseDoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
+        let pma = daachorse::CharwiseDoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
         b.iter(|| {
             let mut sum = 0;
             for haystack in haystacks {
@@ -511,7 +506,7 @@ fn add_find_leftmost_longest_benches(
 
     group.bench_function("daachorse/charwise", |b| {
         let pma: daachorse::CharwiseDoubleArrayAhoCorasick<usize> =
-            daachorse::charwise::CharwiseDoubleArrayAhoCorasickBuilder::new()
+            daachorse::CharwiseDoubleArrayAhoCorasickBuilder::new()
                 .match_kind(daachorse::MatchKind::LeftmostLongest)
                 .build(patterns)
                 .unwrap();
@@ -590,7 +585,7 @@ fn add_find_leftmost_first_benches(
 
     group.bench_function("daachorse/charwise", |b| {
         let pma: daachorse::CharwiseDoubleArrayAhoCorasick<usize> =
-            daachorse::charwise::CharwiseDoubleArrayAhoCorasickBuilder::new()
+            daachorse::CharwiseDoubleArrayAhoCorasickBuilder::new()
                 .match_kind(daachorse::MatchKind::LeftmostFirst)
                 .build(patterns)
                 .unwrap();

--- a/bench/src/memory.rs
+++ b/bench/src/memory.rs
@@ -43,8 +43,7 @@ fn show_memory_stats(patterns: &[String]) {
         format_memory("daachorse (bytewise)", pma.heap_bytes());
     }
     {
-        let pma =
-            daachorse::charwise::CharwiseDoubleArrayAhoCorasick::<u32>::new(patterns).unwrap();
+        let pma = daachorse::CharwiseDoubleArrayAhoCorasick::<u32>::new(patterns).unwrap();
         format_memory("daachorse (charwise)", pma.heap_bytes());
     }
     {

--- a/bench/src/memory.rs
+++ b/bench/src/memory.rs
@@ -39,11 +39,12 @@ fn main() {
 
 fn show_memory_stats(patterns: &[String]) {
     {
-        let pma = daachorse::DoubleArrayAhoCorasick::new(patterns).unwrap();
+        let pma = daachorse::DoubleArrayAhoCorasick::<u32>::new(patterns).unwrap();
         format_memory("daachorse (bytewise)", pma.heap_bytes());
     }
     {
-        let pma = daachorse::charwise::CharwiseDoubleArrayAhoCorasick::new(patterns).unwrap();
+        let pma =
+            daachorse::charwise::CharwiseDoubleArrayAhoCorasick::<u32>::new(patterns).unwrap();
         format_memory("daachorse (charwise)", pma.heap_bytes());
     }
     {

--- a/daacfind/src/main.rs
+++ b/daacfind/src/main.rs
@@ -57,7 +57,7 @@ struct Args {
 /// Finds patterns using the given PMA and prints lines to the given `stream`.
 /// When no pattern is found, this function does not print any string.
 fn find_and_output(
-    pma: &DoubleArrayAhoCorasick,
+    pma: &DoubleArrayAhoCorasick<u32>,
     line: &str,
     filename: Option<&str>,
     line_no: Option<usize>,

--- a/src/bytewise.rs
+++ b/src/bytewise.rs
@@ -61,7 +61,7 @@ pub struct DoubleArrayAhoCorasick<V> {
 impl<V> DoubleArrayAhoCorasick<V> {
     /// Creates a new [`DoubleArrayAhoCorasick`] from input patterns. The value `i` is
     /// automatically associated with `patterns[i]`. If the conversion from the index value to the
-    /// specified type fails, a default value is assigned.
+    /// specified type `V` fails, a default value is assigned.
     ///
     /// # Arguments
     ///

--- a/src/bytewise.rs
+++ b/src/bytewise.rs
@@ -44,7 +44,7 @@ const DEAD_STATE_IDX: u32 = 1;
 ///   assigning unique identifiers in the input order.
 ///
 /// - [`DoubleArrayAhoCorasick::with_values`] builds an automaton from a set of pairs of a byte
-///   string and a [`u32`] value.
+///   string and a user-defined value.
 ///
 /// # Limitations
 ///

--- a/src/bytewise.rs
+++ b/src/bytewise.rs
@@ -60,7 +60,8 @@ pub struct DoubleArrayAhoCorasick<V> {
 
 impl<V> DoubleArrayAhoCorasick<V> {
     /// Creates a new [`DoubleArrayAhoCorasick`] from input patterns. The value `i` is
-    /// automatically associated with `patterns[i]`.
+    /// automatically associated with `patterns[i]`. If the conversion from the index value to the
+    /// specified type fails, a default value is assigned.
     ///
     /// # Arguments
     ///

--- a/src/bytewise.rs
+++ b/src/bytewise.rs
@@ -477,17 +477,13 @@ impl<V> DoubleArrayAhoCorasick<V> {
     /// ## LeftmostLongest
     ///
     /// ```
-    /// use daachorse::{
-    ///     DoubleArrayAhoCorasick,
-    ///     DoubleArrayAhoCorasickBuilder,
-    ///     MatchKind,
-    /// };
+    /// use daachorse::{DoubleArrayAhoCorasickBuilder, MatchKind};
     ///
     /// let patterns = vec!["ab", "a", "abcd"];
     /// let pma = DoubleArrayAhoCorasickBuilder::new()
-    ///         .match_kind(MatchKind::LeftmostLongest)
-    ///         .build(&patterns)
-    ///         .unwrap();
+    ///     .match_kind(MatchKind::LeftmostLongest)
+    ///     .build(&patterns)
+    ///     .unwrap();
     ///
     /// let mut it = pma.leftmost_find_iter("abcd");
     ///
@@ -500,17 +496,13 @@ impl<V> DoubleArrayAhoCorasick<V> {
     /// ## LeftmostFirst
     ///
     /// ```
-    /// use daachorse::{
-    ///     DoubleArrayAhoCorasick,
-    ///     DoubleArrayAhoCorasickBuilder,
-    ///     MatchKind,
-    /// };
+    /// use daachorse::{DoubleArrayAhoCorasickBuilder, MatchKind};
     ///
     /// let patterns = vec!["ab", "a", "abcd"];
     /// let pma = DoubleArrayAhoCorasickBuilder::new()
-    ///         .match_kind(MatchKind::LeftmostFirst)
-    ///         .build(&patterns)
-    ///         .unwrap();
+    ///     .match_kind(MatchKind::LeftmostFirst)
+    ///     .build(&patterns)
+    ///     .unwrap();
     ///
     /// let mut it = pma.leftmost_find_iter("abcd");
     ///
@@ -622,9 +614,7 @@ impl<V> DoubleArrayAhoCorasick<V> {
     /// let pma = DoubleArrayAhoCorasick::<u32>::new(patterns).unwrap();
     /// let bytes = pma.serialize();
     ///
-    /// let (pma, _) = unsafe {
-    ///     DoubleArrayAhoCorasick::<u32>::deserialize_unchecked(&bytes)
-    /// };
+    /// let (pma, _) = unsafe { DoubleArrayAhoCorasick::<u32>::deserialize_unchecked(&bytes) };
     ///
     /// let mut it = pma.find_overlapping_iter("abcd");
     ///

--- a/src/bytewise.rs
+++ b/src/bytewise.rs
@@ -107,8 +107,7 @@ impl<V> DoubleArrayAhoCorasick<V> {
     ///
     /// # Arguments
     ///
-    /// * `patvals` - List of pattern-value pairs, in which the value is of type [`u32`] and less
-    /// than [`u32::MAX`].
+    /// * `patvals` - List of pattern-value pairs.
     ///
     /// # Errors
     ///

--- a/src/bytewise.rs
+++ b/src/bytewise.rs
@@ -61,7 +61,7 @@ pub struct DoubleArrayAhoCorasick<V> {
 impl<V> DoubleArrayAhoCorasick<V> {
     /// Creates a new [`DoubleArrayAhoCorasick`] from input patterns. The value `i` is
     /// automatically associated with `patterns[i]`. If the conversion from the index value to the
-    /// specified type `V` fails, a default value is assigned.
+    /// specified type `V` fails, [`Default::default()`] is assigned instead.
     ///
     /// # Arguments
     ///

--- a/src/bytewise.rs
+++ b/src/bytewise.rs
@@ -82,7 +82,7 @@ impl<V> DoubleArrayAhoCorasick<V> {
     /// use daachorse::DoubleArrayAhoCorasick;
     ///
     /// let patterns = vec!["bcd", "ab", "a"];
-    /// let pma = DoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
+    /// let pma = DoubleArrayAhoCorasick::new(patterns).unwrap();
     ///
     /// let mut it = pma.find_iter("abcd");
     ///
@@ -166,7 +166,7 @@ impl<V> DoubleArrayAhoCorasick<V> {
     /// use daachorse::DoubleArrayAhoCorasick;
     ///
     /// let patterns = vec!["bcd", "ab", "a"];
-    /// let pma = DoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
+    /// let pma = DoubleArrayAhoCorasick::new(patterns).unwrap();
     ///
     /// let mut it = pma.find_iter("abcd");
     ///
@@ -209,7 +209,7 @@ impl<V> DoubleArrayAhoCorasick<V> {
     /// use daachorse::DoubleArrayAhoCorasick;
     ///
     /// let patterns = vec!["bcd", "ab", "a"];
-    /// let pma = DoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
+    /// let pma = DoubleArrayAhoCorasick::new(patterns).unwrap();
     ///
     /// let haystack = "ab".as_bytes().iter().chain("cd".as_bytes()).copied();
     ///
@@ -254,7 +254,7 @@ impl<V> DoubleArrayAhoCorasick<V> {
     /// use daachorse::DoubleArrayAhoCorasick;
     ///
     /// let patterns = vec!["bcd", "ab", "a"];
-    /// let pma = DoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
+    /// let pma = DoubleArrayAhoCorasick::new(patterns).unwrap();
     ///
     /// let mut it = pma.find_overlapping_iter("abcd");
     ///
@@ -306,7 +306,7 @@ impl<V> DoubleArrayAhoCorasick<V> {
     /// use daachorse::DoubleArrayAhoCorasick;
     ///
     /// let patterns = vec!["bcd", "ab", "a"];
-    /// let pma = DoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
+    /// let pma = DoubleArrayAhoCorasick::new(patterns).unwrap();
     ///
     /// let haystack = "ab".as_bytes().iter().chain("cd".as_bytes()).copied();
     ///
@@ -363,7 +363,7 @@ impl<V> DoubleArrayAhoCorasick<V> {
     /// use daachorse::DoubleArrayAhoCorasick;
     ///
     /// let patterns = vec!["bcd", "cd", "abc"];
-    /// let pma = DoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
+    /// let pma = DoubleArrayAhoCorasick::new(patterns).unwrap();
     ///
     /// let mut it = pma.find_overlapping_no_suffix_iter("abcd");
     ///
@@ -416,7 +416,7 @@ impl<V> DoubleArrayAhoCorasick<V> {
     /// use daachorse::DoubleArrayAhoCorasick;
     ///
     /// let patterns = vec!["bcd", "cd", "abc"];
-    /// let pma = DoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
+    /// let pma = DoubleArrayAhoCorasick::new(patterns).unwrap();
     ///
     /// let haystack = "ab".as_bytes().iter().chain("cd".as_bytes()).copied();
     ///
@@ -484,10 +484,10 @@ impl<V> DoubleArrayAhoCorasick<V> {
     /// };
     ///
     /// let patterns = vec!["ab", "a", "abcd"];
-    /// let pma: DoubleArrayAhoCorasick<usize> = DoubleArrayAhoCorasickBuilder::new()
-    ///           .match_kind(MatchKind::LeftmostLongest)
-    ///           .build(&patterns)
-    ///           .unwrap();
+    /// let pma = DoubleArrayAhoCorasickBuilder::new()
+    ///         .match_kind(MatchKind::LeftmostLongest)
+    ///         .build(&patterns)
+    ///         .unwrap();
     ///
     /// let mut it = pma.leftmost_find_iter("abcd");
     ///
@@ -507,10 +507,10 @@ impl<V> DoubleArrayAhoCorasick<V> {
     /// };
     ///
     /// let patterns = vec!["ab", "a", "abcd"];
-    /// let pma: DoubleArrayAhoCorasick<usize> = DoubleArrayAhoCorasickBuilder::new()
-    ///           .match_kind(MatchKind::LeftmostFirst)
-    ///           .build(&patterns)
-    ///           .unwrap();
+    /// let pma = DoubleArrayAhoCorasickBuilder::new()
+    ///         .match_kind(MatchKind::LeftmostFirst)
+    ///         .build(&patterns)
+    ///         .unwrap();
     ///
     /// let mut it = pma.leftmost_find_iter("abcd");
     ///

--- a/src/bytewise/builder.rs
+++ b/src/bytewise/builder.rs
@@ -170,8 +170,7 @@ impl DoubleArrayAhoCorasickBuilder {
     ///
     /// # Arguments
     ///
-    /// * `patvals` - List of pattern-value pairs, where the value is of type [`u32`] and less than
-    /// [`u32::MAX`].
+    /// * `patvals` - List of pattern-value pairs.
     ///
     /// # Errors
     ///

--- a/src/bytewise/builder.rs
+++ b/src/bytewise/builder.rs
@@ -14,7 +14,7 @@ use crate::utils::FromU32;
 const BLOCK_LEN: u32 = 256;
 
 // Specialized [`NfaBuilder`] handling labels of `u8`.
-type BytewiseNfaBuilder = NfaBuilder<u8>;
+type BytewiseNfaBuilder<V> = NfaBuilder<u8, V>;
 
 /// Builder of [`DoubleArrayAhoCorasick`].
 pub struct DoubleArrayAhoCorasickBuilder {
@@ -150,17 +150,18 @@ impl DoubleArrayAhoCorasickBuilder {
     ///
     /// assert_eq!(None, it.next());
     /// ```
-    pub fn build<I, P>(self, patterns: I) -> Result<DoubleArrayAhoCorasick>
+    pub fn build<I, P, V>(self, patterns: I) -> Result<DoubleArrayAhoCorasick<V>>
     where
         I: IntoIterator<Item = P>,
         P: AsRef<[u8]>,
+        V: Copy + Default + TryFrom<usize>,
     {
         // The following code implicitly replaces large indices with 0,
         // but build_with_values() returns an error variant for such iterators.
         let patvals = patterns
             .into_iter()
             .enumerate()
-            .map(|(i, p)| (p, u32::try_from(i).unwrap_or(0)));
+            .map(|(i, p)| (p, V::try_from(i).unwrap_or_default()));
         self.build_with_values(patvals)
     }
 
@@ -204,10 +205,11 @@ impl DoubleArrayAhoCorasickBuilder {
     ///
     /// assert_eq!(None, it.next());
     /// ```
-    pub fn build_with_values<I, P>(mut self, patvals: I) -> Result<DoubleArrayAhoCorasick>
+    pub fn build_with_values<I, P, V>(mut self, patvals: I) -> Result<DoubleArrayAhoCorasick<V>>
     where
-        I: IntoIterator<Item = (P, u32)>,
+        I: IntoIterator<Item = (P, V)>,
         P: AsRef<[u8]>,
+        V: Copy + Default,
     {
         let nfa = self.build_sparse_nfa(patvals)?;
         self.build_double_array(&nfa)?;
@@ -224,10 +226,11 @@ impl DoubleArrayAhoCorasickBuilder {
         })
     }
 
-    fn build_sparse_nfa<I, P>(&mut self, patvals: I) -> Result<BytewiseNfaBuilder>
+    fn build_sparse_nfa<I, P, V>(&mut self, patvals: I) -> Result<BytewiseNfaBuilder<V>>
     where
-        I: IntoIterator<Item = (P, u32)>,
+        I: IntoIterator<Item = (P, V)>,
         P: AsRef<[u8]>,
+        V: Copy + Default,
     {
         let mut nfa = BytewiseNfaBuilder::new(self.match_kind);
         for (pattern, value) in patvals {
@@ -247,7 +250,7 @@ impl DoubleArrayAhoCorasickBuilder {
         Ok(nfa)
     }
 
-    fn build_double_array(&mut self, nfa: &BytewiseNfaBuilder) -> Result<()> {
+    fn build_double_array<V>(&mut self, nfa: &BytewiseNfaBuilder<V>) -> Result<()> {
         let mut helper = self.init_array()?;
 
         let mut state_id_map = vec![DEAD_STATE_IDX; nfa.states.len()];

--- a/src/bytewise/builder.rs
+++ b/src/bytewise/builder.rs
@@ -74,9 +74,9 @@ impl DoubleArrayAhoCorasickBuilder {
     ///
     /// let patterns = vec!["ab", "abcd"];
     /// let pma = DoubleArrayAhoCorasickBuilder::new()
-    ///           .match_kind(MatchKind::LeftmostLongest)
-    ///           .build(&patterns)
-    ///           .unwrap();
+    ///     .match_kind(MatchKind::LeftmostLongest)
+    ///     .build(&patterns)
+    ///     .unwrap();
     ///
     /// let mut it = pma.leftmost_find_iter("abcd");
     ///

--- a/src/bytewise/builder.rs
+++ b/src/bytewise/builder.rs
@@ -116,7 +116,7 @@ impl DoubleArrayAhoCorasickBuilder {
 
     /// Builds and returns a new [`DoubleArrayAhoCorasick`] from input patterns. The value `i` is
     /// automatically associated with `patterns[i]`. If the conversion from the index value to the
-    /// specified type fails, a default value is assigned.
+    /// specified type `V` fails, a default value is assigned.
     ///
     /// # Arguments
     ///

--- a/src/bytewise/builder.rs
+++ b/src/bytewise/builder.rs
@@ -115,7 +115,8 @@ impl DoubleArrayAhoCorasickBuilder {
     }
 
     /// Builds and returns a new [`DoubleArrayAhoCorasick`] from input patterns. The value `i` is
-    /// automatically associated with `patterns[i]`.
+    /// automatically associated with `patterns[i]`. If the conversion from the index value to the
+    /// specified type fails, a default value is assigned.
     ///
     /// # Arguments
     ///

--- a/src/bytewise/builder.rs
+++ b/src/bytewise/builder.rs
@@ -116,7 +116,7 @@ impl DoubleArrayAhoCorasickBuilder {
 
     /// Builds and returns a new [`DoubleArrayAhoCorasick`] from input patterns. The value `i` is
     /// automatically associated with `patterns[i]`. If the conversion from the index value to the
-    /// specified type `V` fails, a default value is assigned.
+    /// specified type `V` fails, [`Default::default()`] is assigned instead.
     ///
     /// # Arguments
     ///

--- a/src/bytewise/iter.rs
+++ b/src/bytewise/iter.rs
@@ -41,16 +41,17 @@ where
 }
 
 /// Iterator created by [`DoubleArrayAhoCorasick::find_iter()`].
-pub struct FindIterator<'a, P> {
-    pub(crate) pma: &'a DoubleArrayAhoCorasick,
+pub struct FindIterator<'a, P, V> {
+    pub(crate) pma: &'a DoubleArrayAhoCorasick<V>,
     pub(crate) haystack: Enumerate<P>,
 }
 
-impl<'a, P> Iterator for FindIterator<'a, P>
+impl<'a, P, V> Iterator for FindIterator<'a, P, V>
 where
     P: Iterator<Item = u8>,
+    V: Copy,
 {
-    type Item = Match;
+    type Item = Match<V>;
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
@@ -75,7 +76,7 @@ where
                 return Some(Match {
                     length: usize::from_u32(out.length()),
                     end: pos + 1,
-                    value: usize::from_u32(out.value()),
+                    value: out.value(),
                 });
             }
         }
@@ -84,19 +85,20 @@ where
 }
 
 /// Iterator created by [`DoubleArrayAhoCorasick::find_overlapping_iter()`].
-pub struct FindOverlappingIterator<'a, P> {
-    pub(crate) pma: &'a DoubleArrayAhoCorasick,
+pub struct FindOverlappingIterator<'a, P, V> {
+    pub(crate) pma: &'a DoubleArrayAhoCorasick<V>,
     pub(crate) haystack: Enumerate<P>,
     pub(crate) state_id: u32,
     pub(crate) pos: usize,
     pub(crate) output_pos: Option<NonZeroU32>,
 }
 
-impl<'a, P> Iterator for FindOverlappingIterator<'a, P>
+impl<'a, P, V> Iterator for FindOverlappingIterator<'a, P, V>
 where
     P: Iterator<Item = u8>,
+    V: Copy,
 {
-    type Item = Match;
+    type Item = Match<V>;
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
@@ -112,7 +114,7 @@ where
             return Some(Match {
                 length: usize::from_u32(out.length()),
                 end: self.pos,
-                value: usize::from_u32(out.value()),
+                value: out.value(),
             });
         }
         for (pos, c) in self.haystack.by_ref() {
@@ -137,7 +139,7 @@ where
                 return Some(Match {
                     length: usize::from_u32(out.length()),
                     end: self.pos,
-                    value: usize::from_u32(out.value()),
+                    value: out.value(),
                 });
             }
         }
@@ -146,17 +148,18 @@ where
 }
 
 /// Iterator created by [`DoubleArrayAhoCorasick::find_overlapping_no_suffix_iter()`].
-pub struct FindOverlappingNoSuffixIterator<'a, P> {
-    pub(crate) pma: &'a DoubleArrayAhoCorasick,
+pub struct FindOverlappingNoSuffixIterator<'a, P, V> {
+    pub(crate) pma: &'a DoubleArrayAhoCorasick<V>,
     pub(crate) haystack: Enumerate<P>,
     pub(crate) state_id: u32,
 }
 
-impl<'a, P> Iterator for FindOverlappingNoSuffixIterator<'a, P>
+impl<'a, P, V> Iterator for FindOverlappingNoSuffixIterator<'a, P, V>
 where
     P: Iterator<Item = u8>,
+    V: Copy,
 {
-    type Item = Match;
+    type Item = Match<V>;
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
@@ -180,7 +183,7 @@ where
                 return Some(Match {
                     length: usize::from_u32(out.length()),
                     end: pos + 1,
-                    value: usize::from_u32(out.value()),
+                    value: out.value(),
                 });
             }
         }
@@ -189,20 +192,21 @@ where
 }
 
 /// Iterator created by [`DoubleArrayAhoCorasick::leftmost_find_iter()`].
-pub struct LestmostFindIterator<'a, P>
+pub struct LestmostFindIterator<'a, P, V>
 where
     P: AsRef<[u8]>,
 {
-    pub(crate) pma: &'a DoubleArrayAhoCorasick,
+    pub(crate) pma: &'a DoubleArrayAhoCorasick<V>,
     pub(crate) haystack: P,
     pub(crate) pos: usize,
 }
 
-impl<'a, P> Iterator for LestmostFindIterator<'a, P>
+impl<'a, P, V> Iterator for LestmostFindIterator<'a, P, V>
 where
     P: AsRef<[u8]>,
+    V: Copy,
 {
-    type Item = Match;
+    type Item = Match<V>;
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
@@ -226,7 +230,7 @@ where
                     return Some(Match {
                         length: usize::from_u32(out.length()),
                         end: self.pos,
-                        value: usize::from_u32(out.value()),
+                        value: out.value(),
                     });
                 }
             // state_id is always smaller than self.pma.states.len() because
@@ -253,7 +257,7 @@ where
             Match {
                 length: usize::from_u32(out.length()),
                 end: self.pos,
-                value: usize::from_u32(out.value()),
+                value: out.value(),
             }
         })
     }

--- a/src/charwise.rs
+++ b/src/charwise.rs
@@ -495,17 +495,13 @@ impl<V> CharwiseDoubleArrayAhoCorasick<V> {
     /// ## LeftmostLongest
     ///
     /// ```
-    /// use daachorse::{
-    ///     CharwiseDoubleArrayAhoCorasick,
-    ///     CharwiseDoubleArrayAhoCorasickBuilder,
-    ///     MatchKind,
-    /// };
+    /// use daachorse::{CharwiseDoubleArrayAhoCorasickBuilder, MatchKind};
     ///
     /// let patterns = vec!["世界", "世", "世界中に"];
     /// let pma = CharwiseDoubleArrayAhoCorasickBuilder::new()
-    ///         .match_kind(MatchKind::LeftmostLongest)
-    ///         .build(&patterns)
-    ///         .unwrap();
+    ///     .match_kind(MatchKind::LeftmostLongest)
+    ///     .build(&patterns)
+    ///     .unwrap();
     ///
     /// let mut it = pma.leftmost_find_iter("世界中に");
     ///
@@ -518,17 +514,13 @@ impl<V> CharwiseDoubleArrayAhoCorasick<V> {
     /// ## LeftmostFirst
     ///
     /// ```
-    /// use daachorse::{
-    ///     CharwiseDoubleArrayAhoCorasick,
-    ///     CharwiseDoubleArrayAhoCorasickBuilder,
-    ///     MatchKind,
-    /// };
+    /// use daachorse::{CharwiseDoubleArrayAhoCorasickBuilder, MatchKind};
     ///
     /// let patterns = vec!["世界", "世", "世界中に"];
     /// let pma = CharwiseDoubleArrayAhoCorasickBuilder::new()
-    ///         .match_kind(MatchKind::LeftmostFirst)
-    ///         .build(&patterns)
-    ///         .unwrap();
+    ///     .match_kind(MatchKind::LeftmostFirst)
+    ///     .build(&patterns)
+    ///     .unwrap();
     ///
     /// let mut it = pma.leftmost_find_iter("世界中に");
     ///
@@ -660,9 +652,7 @@ impl<V> CharwiseDoubleArrayAhoCorasick<V> {
     /// let pma = CharwiseDoubleArrayAhoCorasick::<u32>::new(patterns).unwrap();
     /// let bytes = pma.serialize();
     ///
-    /// let (pma, _) = unsafe {
-    ///     CharwiseDoubleArrayAhoCorasick::<u32>::deserialize_unchecked(&bytes)
-    /// };
+    /// let (pma, _) = unsafe { CharwiseDoubleArrayAhoCorasick::<u32>::deserialize_unchecked(&bytes) };
     ///
     /// let mut it = pma.find_overlapping_iter("全世界中に");
     ///

--- a/src/charwise.rs
+++ b/src/charwise.rs
@@ -87,7 +87,7 @@ impl<V> CharwiseDoubleArrayAhoCorasick<V> {
     /// use daachorse::CharwiseDoubleArrayAhoCorasick;
     ///
     /// let patterns = vec!["全世界", "世界", "に"];
-    /// let pma = CharwiseDoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
+    /// let pma = CharwiseDoubleArrayAhoCorasick::new(patterns).unwrap();
     ///
     /// let mut it = pma.find_iter("全世界中に");
     ///
@@ -169,7 +169,7 @@ impl<V> CharwiseDoubleArrayAhoCorasick<V> {
     /// use daachorse::CharwiseDoubleArrayAhoCorasick;
     ///
     /// let patterns = vec!["全世界", "世界", "に"];
-    /// let pma = CharwiseDoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
+    /// let pma = CharwiseDoubleArrayAhoCorasick::new(patterns).unwrap();
     ///
     /// let mut it = pma.find_iter("全世界中に");
     ///
@@ -216,7 +216,7 @@ impl<V> CharwiseDoubleArrayAhoCorasick<V> {
     /// use daachorse::CharwiseDoubleArrayAhoCorasick;
     ///
     /// let patterns = vec!["全世界", "世界", "に"];
-    /// let pma = CharwiseDoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
+    /// let pma = CharwiseDoubleArrayAhoCorasick::new(patterns).unwrap();
     ///
     /// let haystack = "全世界".as_bytes().iter().chain("中に".as_bytes()).copied();
     ///
@@ -261,7 +261,7 @@ impl<V> CharwiseDoubleArrayAhoCorasick<V> {
     /// use daachorse::CharwiseDoubleArrayAhoCorasick;
     ///
     /// let patterns = vec!["全世界", "世界", "に"];
-    /// let pma = CharwiseDoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
+    /// let pma = CharwiseDoubleArrayAhoCorasick::new(patterns).unwrap();
     ///
     /// let mut it = pma.find_overlapping_iter("全世界中に");
     ///
@@ -317,7 +317,7 @@ impl<V> CharwiseDoubleArrayAhoCorasick<V> {
     /// use daachorse::CharwiseDoubleArrayAhoCorasick;
     ///
     /// let patterns = vec!["全世界", "世界", "に"];
-    /// let pma = CharwiseDoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
+    /// let pma = CharwiseDoubleArrayAhoCorasick::new(patterns).unwrap();
     ///
     /// let haystack = "全世界".as_bytes().iter().chain("中に".as_bytes()).copied();
     ///
@@ -377,7 +377,7 @@ impl<V> CharwiseDoubleArrayAhoCorasick<V> {
     /// use daachorse::CharwiseDoubleArrayAhoCorasick;
     ///
     /// let patterns = vec!["全世界", "世界", "に"];
-    /// let pma = CharwiseDoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
+    /// let pma = CharwiseDoubleArrayAhoCorasick::new(patterns).unwrap();
     ///
     /// let mut it = pma.find_overlapping_no_suffix_iter("全世界中に");
     ///
@@ -434,7 +434,7 @@ impl<V> CharwiseDoubleArrayAhoCorasick<V> {
     /// use daachorse::CharwiseDoubleArrayAhoCorasick;
     ///
     /// let patterns = vec!["全世界", "世界", "に"];
-    /// let pma = CharwiseDoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
+    /// let pma = CharwiseDoubleArrayAhoCorasick::new(patterns).unwrap();
     ///
     /// let haystack = "全世界".as_bytes().iter().chain("中に".as_bytes()).copied();
     ///
@@ -502,11 +502,10 @@ impl<V> CharwiseDoubleArrayAhoCorasick<V> {
     /// };
     ///
     /// let patterns = vec!["世界", "世", "世界中に"];
-    /// let pma: CharwiseDoubleArrayAhoCorasick<usize>
-    ///     = CharwiseDoubleArrayAhoCorasickBuilder::new()
-    ///           .match_kind(MatchKind::LeftmostLongest)
-    ///           .build(&patterns)
-    ///           .unwrap();
+    /// let pma = CharwiseDoubleArrayAhoCorasickBuilder::new()
+    ///         .match_kind(MatchKind::LeftmostLongest)
+    ///         .build(&patterns)
+    ///         .unwrap();
     ///
     /// let mut it = pma.leftmost_find_iter("世界中に");
     ///
@@ -526,11 +525,10 @@ impl<V> CharwiseDoubleArrayAhoCorasick<V> {
     /// };
     ///
     /// let patterns = vec!["世界", "世", "世界中に"];
-    /// let pma: CharwiseDoubleArrayAhoCorasick<usize>
-    ///     = CharwiseDoubleArrayAhoCorasickBuilder::new()
-    ///           .match_kind(MatchKind::LeftmostFirst)
-    ///           .build(&patterns)
-    ///           .unwrap();
+    /// let pma = CharwiseDoubleArrayAhoCorasickBuilder::new()
+    ///         .match_kind(MatchKind::LeftmostFirst)
+    ///         .build(&patterns)
+    ///         .unwrap();
     ///
     /// let mut it = pma.leftmost_find_iter("世界中に");
     ///

--- a/src/charwise.rs
+++ b/src/charwise.rs
@@ -112,8 +112,7 @@ impl<V> CharwiseDoubleArrayAhoCorasick<V> {
     ///
     /// # Arguments
     ///
-    /// * `patvals` - List of pattern-value pairs, in which the value is of type [`u32`] and less
-    /// than [`u32::MAX`].
+    /// * `patvals` - List of pattern-value pairs.
     ///
     /// # Errors
     ///

--- a/src/charwise.rs
+++ b/src/charwise.rs
@@ -53,7 +53,7 @@ const DEAD_STATE_IDX: u32 = 1;
 ///   assigning unique identifiers in the input order.
 ///
 /// - [`CharwiseDoubleArrayAhoCorasick::with_values`] builds an automaton
-///   from a set of pairs of a UTF-8 string and a [`u32`] value.
+///   from a set of pairs of a UTF-8 string and a user-defined value.
 #[derive(Clone, Eq, Hash, PartialEq)]
 pub struct CharwiseDoubleArrayAhoCorasick<V> {
     states: Vec<State>,

--- a/src/charwise.rs
+++ b/src/charwise.rs
@@ -66,7 +66,7 @@ pub struct CharwiseDoubleArrayAhoCorasick<V> {
 impl<V> CharwiseDoubleArrayAhoCorasick<V> {
     /// Creates a new [`CharwiseDoubleArrayAhoCorasick`] from input patterns. The value `i` is
     /// automatically associated with `patterns[i]`. If the conversion from the index value to the
-    /// specified type fails, a default value is assigned.
+    /// specified type `V` fails, a default value is assigned.
     ///
     /// # Arguments
     ///

--- a/src/charwise.rs
+++ b/src/charwise.rs
@@ -66,7 +66,7 @@ pub struct CharwiseDoubleArrayAhoCorasick<V> {
 impl<V> CharwiseDoubleArrayAhoCorasick<V> {
     /// Creates a new [`CharwiseDoubleArrayAhoCorasick`] from input patterns. The value `i` is
     /// automatically associated with `patterns[i]`. If the conversion from the index value to the
-    /// specified type `V` fails, a default value is assigned.
+    /// specified type `V` fails, [`Default::default()`] is assigned instead.
     ///
     /// # Arguments
     ///

--- a/src/charwise.rs
+++ b/src/charwise.rs
@@ -55,15 +55,15 @@ const DEAD_STATE_IDX: u32 = 1;
 /// - [`CharwiseDoubleArrayAhoCorasick::with_values`] builds an automaton
 ///   from a set of pairs of a UTF-8 string and a [`u32`] value.
 #[derive(Clone, Eq, Hash, PartialEq)]
-pub struct CharwiseDoubleArrayAhoCorasick {
+pub struct CharwiseDoubleArrayAhoCorasick<V> {
     states: Vec<State>,
     mapper: CodeMapper,
-    outputs: Vec<Output>,
+    outputs: Vec<Output<V>>,
     match_kind: MatchKind,
     num_states: u32,
 }
 
-impl CharwiseDoubleArrayAhoCorasick {
+impl<V> CharwiseDoubleArrayAhoCorasick<V> {
     /// Creates a new [`CharwiseDoubleArrayAhoCorasick`] from input patterns. The value `i` is
     /// automatically associated with `patterns[i]`.
     ///
@@ -86,7 +86,7 @@ impl CharwiseDoubleArrayAhoCorasick {
     /// use daachorse::CharwiseDoubleArrayAhoCorasick;
     ///
     /// let patterns = vec!["全世界", "世界", "に"];
-    /// let pma = CharwiseDoubleArrayAhoCorasick::new(patterns).unwrap();
+    /// let pma = CharwiseDoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
     ///
     /// let mut it = pma.find_iter("全世界中に");
     ///
@@ -102,6 +102,7 @@ impl CharwiseDoubleArrayAhoCorasick {
     where
         I: IntoIterator<Item = P>,
         P: AsRef<str>,
+        V: Copy + Default + TryFrom<usize>,
     {
         CharwiseDoubleArrayAhoCorasickBuilder::new().build(patterns)
     }
@@ -143,8 +144,9 @@ impl CharwiseDoubleArrayAhoCorasick {
     /// ```
     pub fn with_values<I, P>(patvals: I) -> Result<Self>
     where
-        I: IntoIterator<Item = (P, u32)>,
+        I: IntoIterator<Item = (P, V)>,
         P: AsRef<str>,
+        V: Copy + Default,
     {
         CharwiseDoubleArrayAhoCorasickBuilder::new().build_with_values(patvals)
     }
@@ -166,7 +168,7 @@ impl CharwiseDoubleArrayAhoCorasick {
     /// use daachorse::CharwiseDoubleArrayAhoCorasick;
     ///
     /// let patterns = vec!["全世界", "世界", "に"];
-    /// let pma = CharwiseDoubleArrayAhoCorasick::new(patterns).unwrap();
+    /// let pma = CharwiseDoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
     ///
     /// let mut it = pma.find_iter("全世界中に");
     ///
@@ -178,7 +180,7 @@ impl CharwiseDoubleArrayAhoCorasick {
     ///
     /// assert_eq!(None, it.next());
     /// ```
-    pub fn find_iter<P>(&self, haystack: P) -> FindIterator<StrIterator<P>>
+    pub fn find_iter<P>(&self, haystack: P) -> FindIterator<StrIterator<P>, V>
     where
         P: AsRef<str>,
     {
@@ -213,7 +215,7 @@ impl CharwiseDoubleArrayAhoCorasick {
     /// use daachorse::CharwiseDoubleArrayAhoCorasick;
     ///
     /// let patterns = vec!["全世界", "世界", "に"];
-    /// let pma = CharwiseDoubleArrayAhoCorasick::new(patterns).unwrap();
+    /// let pma = CharwiseDoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
     ///
     /// let haystack = "全世界".as_bytes().iter().chain("中に".as_bytes()).copied();
     ///
@@ -227,7 +229,7 @@ impl CharwiseDoubleArrayAhoCorasick {
     ///
     /// assert_eq!(None, it.next());
     /// ```
-    pub unsafe fn find_iter_from_iter<P>(&self, haystack: P) -> FindIterator<P>
+    pub unsafe fn find_iter_from_iter<P>(&self, haystack: P) -> FindIterator<P, V>
     where
         P: Iterator<Item = u8>,
     {
@@ -258,7 +260,7 @@ impl CharwiseDoubleArrayAhoCorasick {
     /// use daachorse::CharwiseDoubleArrayAhoCorasick;
     ///
     /// let patterns = vec!["全世界", "世界", "に"];
-    /// let pma = CharwiseDoubleArrayAhoCorasick::new(patterns).unwrap();
+    /// let pma = CharwiseDoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
     ///
     /// let mut it = pma.find_overlapping_iter("全世界中に");
     ///
@@ -273,7 +275,10 @@ impl CharwiseDoubleArrayAhoCorasick {
     ///
     /// assert_eq!(None, it.next());
     /// ```
-    pub fn find_overlapping_iter<P>(&self, haystack: P) -> FindOverlappingIterator<StrIterator<P>>
+    pub fn find_overlapping_iter<P>(
+        &self,
+        haystack: P,
+    ) -> FindOverlappingIterator<StrIterator<P>, V>
     where
         P: AsRef<str>,
     {
@@ -311,7 +316,7 @@ impl CharwiseDoubleArrayAhoCorasick {
     /// use daachorse::CharwiseDoubleArrayAhoCorasick;
     ///
     /// let patterns = vec!["全世界", "世界", "に"];
-    /// let pma = CharwiseDoubleArrayAhoCorasick::new(patterns).unwrap();
+    /// let pma = CharwiseDoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
     ///
     /// let haystack = "全世界".as_bytes().iter().chain("中に".as_bytes()).copied();
     ///
@@ -331,7 +336,7 @@ impl CharwiseDoubleArrayAhoCorasick {
     pub unsafe fn find_overlapping_iter_from_iter<P>(
         &self,
         haystack: P,
-    ) -> FindOverlappingIterator<P>
+    ) -> FindOverlappingIterator<P, V>
     where
         P: Iterator<Item = u8>,
     {
@@ -371,7 +376,7 @@ impl CharwiseDoubleArrayAhoCorasick {
     /// use daachorse::CharwiseDoubleArrayAhoCorasick;
     ///
     /// let patterns = vec!["全世界", "世界", "に"];
-    /// let pma = CharwiseDoubleArrayAhoCorasick::new(patterns).unwrap();
+    /// let pma = CharwiseDoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
     ///
     /// let mut it = pma.find_overlapping_no_suffix_iter("全世界中に");
     ///
@@ -386,7 +391,7 @@ impl CharwiseDoubleArrayAhoCorasick {
     pub fn find_overlapping_no_suffix_iter<P>(
         &self,
         haystack: P,
-    ) -> FindOverlappingNoSuffixIterator<StrIterator<P>>
+    ) -> FindOverlappingNoSuffixIterator<StrIterator<P>, V>
     where
         P: AsRef<str>,
     {
@@ -428,7 +433,7 @@ impl CharwiseDoubleArrayAhoCorasick {
     /// use daachorse::CharwiseDoubleArrayAhoCorasick;
     ///
     /// let patterns = vec!["全世界", "世界", "に"];
-    /// let pma = CharwiseDoubleArrayAhoCorasick::new(patterns).unwrap();
+    /// let pma = CharwiseDoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
     ///
     /// let haystack = "全世界".as_bytes().iter().chain("中に".as_bytes()).copied();
     ///
@@ -445,7 +450,7 @@ impl CharwiseDoubleArrayAhoCorasick {
     pub unsafe fn find_overlapping_no_suffix_iter_from_iter<P>(
         &self,
         haystack: P,
-    ) -> FindOverlappingNoSuffixIterator<P>
+    ) -> FindOverlappingNoSuffixIterator<P, V>
     where
         P: Iterator<Item = u8>,
     {
@@ -489,10 +494,15 @@ impl CharwiseDoubleArrayAhoCorasick {
     /// ## LeftmostLongest
     ///
     /// ```
-    /// use daachorse::{CharwiseDoubleArrayAhoCorasickBuilder, MatchKind};
+    /// use daachorse::{
+    ///     CharwiseDoubleArrayAhoCorasick,
+    ///     CharwiseDoubleArrayAhoCorasickBuilder,
+    ///     MatchKind,
+    /// };
     ///
     /// let patterns = vec!["世界", "世", "世界中に"];
-    /// let pma = CharwiseDoubleArrayAhoCorasickBuilder::new()
+    /// let pma: CharwiseDoubleArrayAhoCorasick<usize>
+    ///     = CharwiseDoubleArrayAhoCorasickBuilder::new()
     ///           .match_kind(MatchKind::LeftmostLongest)
     ///           .build(&patterns)
     ///           .unwrap();
@@ -508,10 +518,15 @@ impl CharwiseDoubleArrayAhoCorasick {
     /// ## LeftmostFirst
     ///
     /// ```
-    /// use daachorse::{CharwiseDoubleArrayAhoCorasickBuilder, MatchKind};
+    /// use daachorse::{
+    ///     CharwiseDoubleArrayAhoCorasick,
+    ///     CharwiseDoubleArrayAhoCorasickBuilder,
+    ///     MatchKind,
+    /// };
     ///
     /// let patterns = vec!["世界", "世", "世界中に"];
-    /// let pma = CharwiseDoubleArrayAhoCorasickBuilder::new()
+    /// let pma: CharwiseDoubleArrayAhoCorasick<usize>
+    ///     = CharwiseDoubleArrayAhoCorasickBuilder::new()
     ///           .match_kind(MatchKind::LeftmostFirst)
     ///           .build(&patterns)
     ///           .unwrap();
@@ -523,7 +538,7 @@ impl CharwiseDoubleArrayAhoCorasick {
     ///
     /// assert_eq!(None, it.next());
     /// ```
-    pub fn leftmost_find_iter<P>(&self, haystack: P) -> LestmostFindIterator<P>
+    pub fn leftmost_find_iter<P>(&self, haystack: P) -> LestmostFindIterator<P, V>
     where
         P: AsRef<str>,
     {
@@ -546,7 +561,7 @@ impl CharwiseDoubleArrayAhoCorasick {
     /// use daachorse::CharwiseDoubleArrayAhoCorasick;
     ///
     /// let patterns = vec!["bcd", "ab", "a"];
-    /// let pma = CharwiseDoubleArrayAhoCorasick::new(patterns).unwrap();
+    /// let pma = CharwiseDoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
     ///
     /// assert_eq!(pma.num_states(), 6);
     /// ```
@@ -563,7 +578,7 @@ impl CharwiseDoubleArrayAhoCorasick {
     /// use daachorse::CharwiseDoubleArrayAhoCorasick;
     ///
     /// let patterns = vec!["bcd", "ab", "a"];
-    /// let pma = CharwiseDoubleArrayAhoCorasick::new(patterns).unwrap();
+    /// let pma = CharwiseDoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
     ///
     /// assert_eq!(pma.num_elements(), 8);
     /// ```
@@ -580,7 +595,7 @@ impl CharwiseDoubleArrayAhoCorasick {
     /// use daachorse::CharwiseDoubleArrayAhoCorasick;
     ///
     /// let patterns = vec!["bcd", "ab", "a"];
-    /// let pma = CharwiseDoubleArrayAhoCorasick::new(patterns).unwrap();
+    /// let pma = CharwiseDoubleArrayAhoCorasick::<u32>::new(patterns).unwrap();
     ///
     /// assert_eq!(580, pma.heap_bytes());
     /// ```
@@ -588,7 +603,7 @@ impl CharwiseDoubleArrayAhoCorasick {
     pub fn heap_bytes(&self) -> usize {
         self.states.len() * mem::size_of::<State>()
             + self.mapper.heap_bytes()
-            + self.outputs.len() * mem::size_of::<Output>()
+            + self.outputs.len() * mem::size_of::<Output<V>>()
     }
 
     /// Serializes the automaton into a [`Vec`].
@@ -599,11 +614,14 @@ impl CharwiseDoubleArrayAhoCorasick {
     /// use daachorse::CharwiseDoubleArrayAhoCorasick;
     ///
     /// let patterns = vec!["全世界", "世界", "に"];
-    /// let pma = CharwiseDoubleArrayAhoCorasick::new(patterns).unwrap();
+    /// let pma = CharwiseDoubleArrayAhoCorasick::<u32>::new(patterns).unwrap();
     /// let bytes = pma.serialize();
     /// ```
     #[must_use]
-    pub fn serialize(&self) -> Vec<u8> {
+    pub fn serialize(&self) -> Vec<u8>
+    where
+        V: Serializable,
+    {
         let mut result = Vec::with_capacity(
             self.states.serialized_bytes()
                 + self.mapper.serialized_bytes()
@@ -640,11 +658,11 @@ impl CharwiseDoubleArrayAhoCorasick {
     /// use daachorse::CharwiseDoubleArrayAhoCorasick;
     ///
     /// let patterns = vec!["全世界", "世界", "に"];
-    /// let pma = CharwiseDoubleArrayAhoCorasick::new(patterns).unwrap();
+    /// let pma = CharwiseDoubleArrayAhoCorasick::<u32>::new(patterns).unwrap();
     /// let bytes = pma.serialize();
     ///
     /// let (pma, _) = unsafe {
-    ///     CharwiseDoubleArrayAhoCorasick::deserialize_unchecked(&bytes)
+    ///     CharwiseDoubleArrayAhoCorasick::<u32>::deserialize_unchecked(&bytes)
     /// };
     ///
     /// let mut it = pma.find_overlapping_iter("全世界中に");
@@ -661,10 +679,13 @@ impl CharwiseDoubleArrayAhoCorasick {
     /// assert_eq!(None, it.next());
     /// ```
     #[must_use]
-    pub unsafe fn deserialize_unchecked(source: &[u8]) -> (Self, &[u8]) {
+    pub unsafe fn deserialize_unchecked(source: &[u8]) -> (Self, &[u8])
+    where
+        V: Serializable,
+    {
         let (states, source) = Vec::<State>::deserialize_from_slice(source);
         let (mapper, source) = CodeMapper::deserialize_from_slice(source);
-        let (outputs, source) = Vec::<Output>::deserialize_from_slice(source);
+        let (outputs, source) = Vec::<Output<V>>::deserialize_from_slice(source);
         let (match_kind, source) = MatchKind::deserialize_from_slice(source);
         let (num_states, source) = u32::deserialize_from_slice(source);
         (
@@ -874,7 +895,7 @@ mod tests {
     #[test]
     fn test_serialize_pma() {
         let patterns = vec!["全世界", "世界", "に"];
-        let pma = CharwiseDoubleArrayAhoCorasick::new(patterns).unwrap();
+        let pma = CharwiseDoubleArrayAhoCorasick::<u32>::new(patterns).unwrap();
         let bytes = pma.serialize();
         let (other, rest) =
             unsafe { CharwiseDoubleArrayAhoCorasick::deserialize_unchecked(&bytes) };

--- a/src/charwise.rs
+++ b/src/charwise.rs
@@ -65,7 +65,8 @@ pub struct CharwiseDoubleArrayAhoCorasick<V> {
 
 impl<V> CharwiseDoubleArrayAhoCorasick<V> {
     /// Creates a new [`CharwiseDoubleArrayAhoCorasick`] from input patterns. The value `i` is
-    /// automatically associated with `patterns[i]`.
+    /// automatically associated with `patterns[i]`. If the conversion from the index value to the
+    /// specified type fails, a default value is assigned.
     ///
     /// # Arguments
     ///

--- a/src/charwise/builder.rs
+++ b/src/charwise/builder.rs
@@ -95,7 +95,7 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
 
     /// Builds and returns a new [`CharwiseDoubleArrayAhoCorasick`] from input patterns. The value
     /// `i` is automatically associated with `patterns[i]`. If the conversion from the index value to the
-    /// specified type fails, a default value is assigned.
+    /// specified type `V` fails, a default value is assigned.
     ///
     /// # Arguments
     ///

--- a/src/charwise/builder.rs
+++ b/src/charwise/builder.rs
@@ -94,7 +94,8 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
     }
 
     /// Builds and returns a new [`CharwiseDoubleArrayAhoCorasick`] from input patterns. The value
-    /// `i` is automatically associated with `patterns[i]`.
+    /// `i` is automatically associated with `patterns[i]`. If the conversion from the index value to the
+    /// specified type fails, a default value is assigned.
     ///
     /// # Arguments
     ///

--- a/src/charwise/builder.rs
+++ b/src/charwise/builder.rs
@@ -149,8 +149,7 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
     ///
     /// # Arguments
     ///
-    /// * `patvals` - List of pattern-value pairs, where the value is of type [`u32`] and less than
-    /// [`u32::MAX`].
+    /// * `patvals` - List of pattern-value pairs.
     ///
     /// # Errors
     ///

--- a/src/charwise/builder.rs
+++ b/src/charwise/builder.rs
@@ -95,7 +95,7 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
 
     /// Builds and returns a new [`CharwiseDoubleArrayAhoCorasick`] from input patterns. The value
     /// `i` is automatically associated with `patterns[i]`. If the conversion from the index value to the
-    /// specified type `V` fails, a default value is assigned.
+    /// specified type `V` fails, [`Default::default()`] is assigned instead.
     ///
     /// # Arguments
     ///

--- a/src/charwise/builder.rs
+++ b/src/charwise/builder.rs
@@ -116,7 +116,9 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
     /// use daachorse::CharwiseDoubleArrayAhoCorasickBuilder;
     ///
     /// let patterns = vec!["全世界", "世界", "に"];
-    /// let pma = CharwiseDoubleArrayAhoCorasickBuilder::new().build(patterns).unwrap();
+    /// let pma = CharwiseDoubleArrayAhoCorasickBuilder::new()
+    ///     .build(patterns)
+    ///     .unwrap();
     ///
     /// let mut it = pma.find_iter("全世界中に");
     ///
@@ -166,7 +168,9 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
     /// use daachorse::CharwiseDoubleArrayAhoCorasickBuilder;
     ///
     /// let patvals = vec![("全世界", 0), ("世界", 10), ("に", 100)];
-    /// let pma = CharwiseDoubleArrayAhoCorasickBuilder::new().build_with_values(patvals).unwrap();
+    /// let pma = CharwiseDoubleArrayAhoCorasickBuilder::new()
+    ///     .build_with_values(patvals)
+    ///     .unwrap();
     ///
     /// let mut it = pma.find_iter("全世界中に");
     ///

--- a/src/charwise/iter.rs
+++ b/src/charwise/iter.rs
@@ -99,8 +99,8 @@ where
 }
 
 /// Iterator created by [`CharwiseDoubleArrayAhoCorasick::find_iter()`].
-pub struct FindOverlappingIterator<'a, P> {
-    pub(crate) pma: &'a CharwiseDoubleArrayAhoCorasick,
+pub struct FindOverlappingIterator<'a, P, V> {
+    pub(crate) pma: &'a CharwiseDoubleArrayAhoCorasick<V>,
     pub(crate) haystack: CharWithEndOffsetIterator<P>,
     pub(crate) state_id: u32,
     pub(crate) pos: usize,
@@ -108,30 +108,31 @@ pub struct FindOverlappingIterator<'a, P> {
 }
 
 /// Iterator created by [`CharwiseDoubleArrayAhoCorasick::find_overlapping_iter()`].
-pub struct FindIterator<'a, P> {
-    pub(crate) pma: &'a CharwiseDoubleArrayAhoCorasick,
+pub struct FindIterator<'a, P, V> {
+    pub(crate) pma: &'a CharwiseDoubleArrayAhoCorasick<V>,
     pub(crate) haystack: CharWithEndOffsetIterator<P>,
 }
 
 /// Iterator created by [`CharwiseDoubleArrayAhoCorasick::find_overlapping_no_suffix_iter()`].
-pub struct FindOverlappingNoSuffixIterator<'a, P> {
-    pub(crate) pma: &'a CharwiseDoubleArrayAhoCorasick,
+pub struct FindOverlappingNoSuffixIterator<'a, P, V> {
+    pub(crate) pma: &'a CharwiseDoubleArrayAhoCorasick<V>,
     pub(crate) haystack: CharWithEndOffsetIterator<P>,
     pub(crate) state_id: u32,
 }
 
 /// Iterator created by [`CharwiseDoubleArrayAhoCorasick::leftmost_find_iter()`].
-pub struct LestmostFindIterator<'a, P> {
-    pub(crate) pma: &'a CharwiseDoubleArrayAhoCorasick,
+pub struct LestmostFindIterator<'a, P, V> {
+    pub(crate) pma: &'a CharwiseDoubleArrayAhoCorasick<V>,
     pub(crate) haystack: P,
     pub(crate) pos: usize,
 }
 
-impl<'a, P> Iterator for FindOverlappingIterator<'a, P>
+impl<'a, P, V> Iterator for FindOverlappingIterator<'a, P, V>
 where
     P: Iterator<Item = u8>,
+    V: Copy,
 {
-    type Item = Match;
+    type Item = Match<V>;
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
@@ -147,7 +148,7 @@ where
             return Some(Match {
                 length: usize::from_u32(out.length()),
                 end: self.pos,
-                value: usize::from_u32(out.value()),
+                value: out.value(),
             });
         }
 
@@ -174,7 +175,7 @@ where
                 return Some(Match {
                     length: usize::from_u32(out.length()),
                     end: pos,
-                    value: usize::from_u32(out.value()),
+                    value: out.value(),
                 });
             }
         }
@@ -182,11 +183,12 @@ where
     }
 }
 
-impl<'a, P> Iterator for FindIterator<'a, P>
+impl<'a, P, V> Iterator for FindIterator<'a, P, V>
 where
     P: Iterator<Item = u8>,
+    V: Copy,
 {
-    type Item = Match;
+    type Item = Match<V>;
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
@@ -211,7 +213,7 @@ where
                 return Some(Match {
                     length: usize::from_u32(out.length()),
                     end: pos,
-                    value: usize::from_u32(out.value()),
+                    value: out.value(),
                 });
             }
         }
@@ -219,11 +221,12 @@ where
     }
 }
 
-impl<'a, P> Iterator for FindOverlappingNoSuffixIterator<'a, P>
+impl<'a, P, V> Iterator for FindOverlappingNoSuffixIterator<'a, P, V>
 where
     P: Iterator<Item = u8>,
+    V: Copy,
 {
-    type Item = Match;
+    type Item = Match<V>;
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
@@ -247,7 +250,7 @@ where
                 return Some(Match {
                     length: usize::from_u32(out.length()),
                     end: pos,
-                    value: usize::from_u32(out.value()),
+                    value: out.value(),
                 });
             }
         }
@@ -255,11 +258,12 @@ where
     }
 }
 
-impl<'a, P> Iterator for LestmostFindIterator<'a, P>
+impl<'a, P, V> Iterator for LestmostFindIterator<'a, P, V>
 where
     P: AsRef<str>,
+    V: Copy,
 {
-    type Item = Match;
+    type Item = Match<V>;
 
     #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
@@ -285,7 +289,7 @@ where
                     return Some(Match {
                         length: usize::from_u32(out.length()),
                         end: self.pos,
-                        value: usize::from_u32(out.value()),
+                        value: out.value(),
                     });
                 }
             // state_id is always smaller than self.pma.states.len() because
@@ -313,7 +317,7 @@ where
             Match {
                 length: usize::from_u32(out.length()),
                 end: self.pos,
-                value: usize::from_u32(out.value()),
+                value: out.value(),
             }
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,13 +75,13 @@
 //! [`MatchKind::LeftmostLongest`] in the construction.
 //!
 //! ```
-//! use daachorse::{DoubleArrayAhoCorasick, DoubleArrayAhoCorasickBuilder, MatchKind};
+//! use daachorse::{DoubleArrayAhoCorasickBuilder, MatchKind};
 //!
 //! let patterns = vec!["ab", "a", "abcd"];
 //! let pma = DoubleArrayAhoCorasickBuilder::new()
-//!           .match_kind(MatchKind::LeftmostLongest)
-//!           .build(&patterns)
-//!           .unwrap();
+//!     .match_kind(MatchKind::LeftmostLongest)
+//!     .build(&patterns)
+//!     .unwrap();
 //!
 //! let mut it = pma.leftmost_find_iter("abcd");
 //!
@@ -105,13 +105,13 @@
 //! `ab` is reported because it is the earliest registered one.
 //!
 //! ```
-//! use daachorse::{DoubleArrayAhoCorasick, DoubleArrayAhoCorasickBuilder, MatchKind};
+//! use daachorse::{DoubleArrayAhoCorasickBuilder, MatchKind};
 //!
 //! let patterns = vec!["ab", "a", "abcd"];
 //! let pma = DoubleArrayAhoCorasickBuilder::new()
-//!           .match_kind(MatchKind::LeftmostFirst)
-//!           .build(&patterns)
-//!           .unwrap();
+//!     .match_kind(MatchKind::LeftmostFirst)
+//!     .build(&patterns)
+//!     .unwrap();
 //!
 //! let mut it = pma.leftmost_find_iter("abcd");
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //! use daachorse::DoubleArrayAhoCorasick;
 //!
 //! let patterns = vec!["bcd", "ab", "a"];
-//! let pma = DoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
+//! let pma = DoubleArrayAhoCorasick::new(patterns).unwrap();
 //!
 //! let mut it = pma.find_overlapping_iter("abcd");
 //!
@@ -54,7 +54,7 @@
 //! use daachorse::DoubleArrayAhoCorasick;
 //!
 //! let patterns = vec!["bcd", "ab", "a"];
-//! let pma = DoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
+//! let pma = DoubleArrayAhoCorasick::new(patterns).unwrap();
 //!
 //! let mut it = pma.find_iter("abcd");
 //!
@@ -78,7 +78,7 @@
 //! use daachorse::{DoubleArrayAhoCorasick, DoubleArrayAhoCorasickBuilder, MatchKind};
 //!
 //! let patterns = vec!["ab", "a", "abcd"];
-//! let pma: DoubleArrayAhoCorasick<usize> = DoubleArrayAhoCorasickBuilder::new()
+//! let pma = DoubleArrayAhoCorasickBuilder::new()
 //!           .match_kind(MatchKind::LeftmostLongest)
 //!           .build(&patterns)
 //!           .unwrap();
@@ -108,7 +108,7 @@
 //! use daachorse::{DoubleArrayAhoCorasick, DoubleArrayAhoCorasickBuilder, MatchKind};
 //!
 //! let patterns = vec!["ab", "a", "abcd"];
-//! let pma: DoubleArrayAhoCorasick<usize> = DoubleArrayAhoCorasickBuilder::new()
+//! let pma = DoubleArrayAhoCorasickBuilder::new()
 //!           .match_kind(MatchKind::LeftmostFirst)
 //!           .build(&patterns)
 //!           .unwrap();
@@ -160,7 +160,7 @@
 //! use daachorse::CharwiseDoubleArrayAhoCorasick;
 //!
 //! let patterns = vec!["全世界", "世界", "に"];
-//! let pma = CharwiseDoubleArrayAhoCorasick::<usize>::new(patterns).unwrap();
+//! let pma = CharwiseDoubleArrayAhoCorasick::new(patterns).unwrap();
 //!
 //! let mut it = pma.find_iter("全世界中に");
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,7 +202,7 @@ use alloc::vec::Vec;
 use build_helper::BuildHelper;
 pub use bytewise::{DoubleArrayAhoCorasick, DoubleArrayAhoCorasickBuilder};
 pub use charwise::{CharwiseDoubleArrayAhoCorasick, CharwiseDoubleArrayAhoCorasickBuilder};
-use serializer::Serializable;
+pub use serializer::Serializable;
 
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 struct Output<V> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,8 +215,9 @@ impl<V> Output<V>
 where
     V: Copy,
 {
+    #[allow(clippy::missing_const_for_fn)]
     #[inline(always)]
-    pub const fn new(value: V, length: u32, parent: Option<NonZeroU32>) -> Self {
+    pub fn new(value: V, length: u32, parent: Option<NonZeroU32>) -> Self {
         Self {
             value,
             length,
@@ -224,18 +225,21 @@ where
         }
     }
 
+    #[allow(clippy::missing_const_for_fn)]
     #[inline(always)]
-    pub const fn value(self) -> V {
+    pub fn value(self) -> V {
         self.value
     }
 
+    #[allow(clippy::missing_const_for_fn)]
     #[inline(always)]
-    pub const fn length(self) -> u32 {
+    pub fn length(self) -> u32 {
         self.length
     }
 
+    #[allow(clippy::missing_const_for_fn)]
     #[inline(always)]
-    pub const fn parent(self) -> Option<NonZeroU32> {
+    pub fn parent(self) -> Option<NonZeroU32> {
         self.parent
     }
 }
@@ -285,23 +289,26 @@ where
     V: Copy,
 {
     /// Starting position of the match.
+    #[allow(clippy::missing_const_for_fn)]
     #[inline(always)]
     #[must_use]
-    pub const fn start(&self) -> usize {
+    pub fn start(&self) -> usize {
         self.end - self.length
     }
 
     /// Ending position of the match.
+    #[allow(clippy::missing_const_for_fn)]
     #[inline(always)]
     #[must_use]
-    pub const fn end(&self) -> usize {
+    pub fn end(&self) -> usize {
         self.end
     }
 
     /// Value associated with the pattern.
+    #[allow(clippy::missing_const_for_fn)]
     #[inline(always)]
     #[must_use]
-    pub const fn value(&self) -> V {
+    pub fn value(&self) -> V {
         self.value
     }
 }

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -49,7 +49,7 @@ macro_rules! define_serializable_primitive {
                 $size
             }
         }
-    }
+    };
 }
 
 define_serializable_primitive!(u8, 1);

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -6,11 +6,27 @@ use alloc::vec::Vec;
 
 use crate::utils::FromU32;
 
+/// Trait indicating serializability.
+///
+/// If the type of output value of the automaton implements this trait, the automaton can be
+/// serialized.
 pub trait Serializable: Sized {
+    /// A Function called during serialization.
+    ///
+    /// # Arguments
+    ///
+    /// * `dst` - the destination to which the serialized data is written.
     fn serialize_to_vec(&self, dst: &mut Vec<u8>);
 
+    /// A Function called during deserialization. This function must return the pair of the struct
+    /// and the rest slice.
+    ///
+    /// # Arguments
+    ///
+    /// * `src` - the source slice containing the serialized data.
     fn deserialize_from_slice(src: &[u8]) -> (Self, &[u8]);
 
+    /// Returns the size of serialized data.
     fn serialized_bytes() -> usize;
 }
 

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -11,14 +11,14 @@ use crate::utils::FromU32;
 /// If the type of output value of the automaton implements this trait, the automaton can be
 /// serialized.
 pub trait Serializable: Sized {
-    /// A Function called during serialization.
+    /// A function called during serialization.
     ///
     /// # Arguments
     ///
     /// * `dst` - the destination to which the serialized data is written.
     fn serialize_to_vec(&self, dst: &mut Vec<u8>);
 
-    /// A Function called during deserialization. This function must return the pair of the struct
+    /// A function called during deserialization. This function must return the pair of the struct
     /// and the rest slice.
     ///
     /// # Arguments

--- a/tests/aho_corasick_crate_test.rs
+++ b/tests/aho_corasick_crate_test.rs
@@ -537,8 +537,8 @@ testconfig!(
     |_| ()
 );
 
-fn run_search_tests<F: FnMut(&SearchTest) -> Vec<Match>>(which: TestCollection, mut f: F) {
-    let get_match_triples = |matches: Vec<Match>| -> Vec<(usize, usize, usize)> {
+fn run_search_tests<F: FnMut(&SearchTest) -> Vec<Match<usize>>>(which: TestCollection, mut f: F) {
+    let get_match_triples = |matches: Vec<Match<usize>>| -> Vec<(usize, usize, usize)> {
         matches
             .into_iter()
             .map(|m| (m.value(), m.start(), m.end()))

--- a/tests/invalid_option_test.rs
+++ b/tests/invalid_option_test.rs
@@ -1,9 +1,9 @@
-use daachorse::DoubleArrayAhoCorasickBuilder;
+use daachorse::{DoubleArrayAhoCorasick, DoubleArrayAhoCorasickBuilder};
 
 #[test]
 fn test_large_num_free_blocks() {
-    assert!(DoubleArrayAhoCorasickBuilder::new()
+    let pma: Result<DoubleArrayAhoCorasick<usize>, _> = DoubleArrayAhoCorasickBuilder::new()
         .num_free_blocks(u32::MAX)
-        .build(["pattern"])
-        .is_err());
+        .build(["pattern"]);
+    assert!(pma.is_err());
 }

--- a/tests/invalid_pattern_charwise_test.rs
+++ b/tests/invalid_pattern_charwise_test.rs
@@ -2,87 +2,96 @@ use daachorse::{CharwiseDoubleArrayAhoCorasick, CharwiseDoubleArrayAhoCorasickBu
 
 #[test]
 fn test_empty_pattern() {
-    assert!(CharwiseDoubleArrayAhoCorasick::new([""]).is_err());
+    assert!(CharwiseDoubleArrayAhoCorasick::<usize>::new([""]).is_err());
 }
 
 #[test]
 fn test_empty_set() {
-    assert!(CharwiseDoubleArrayAhoCorasick::new(Vec::<String>::new()).is_err());
+    assert!(CharwiseDoubleArrayAhoCorasick::<usize>::new(Vec::<String>::new()).is_err());
 }
 
 #[test]
 fn test_duplicate_patterns() {
-    assert!(CharwiseDoubleArrayAhoCorasick::new(["abc", "123", "abc",]).is_err());
+    assert!(CharwiseDoubleArrayAhoCorasick::<usize>::new(["abc", "123", "abc",]).is_err());
 }
 
 #[test]
 fn test_empty_pattern_with_matchkind_leftmost_longest() {
-    assert!(CharwiseDoubleArrayAhoCorasickBuilder::new()
-        .match_kind(MatchKind::LeftmostLongest)
-        .build([""])
-        .is_err());
+    let pma: Result<CharwiseDoubleArrayAhoCorasick<usize>, _> =
+        CharwiseDoubleArrayAhoCorasickBuilder::new()
+            .match_kind(MatchKind::LeftmostLongest)
+            .build([""]);
+    assert!(pma.is_err());
 }
 
 #[test]
 fn test_empty_set_with_matchkind_leftmost_longest() {
-    assert!(CharwiseDoubleArrayAhoCorasickBuilder::new()
-        .match_kind(MatchKind::LeftmostLongest)
-        .build(Vec::<String>::new())
-        .is_err());
+    let pma: Result<CharwiseDoubleArrayAhoCorasick<usize>, _> =
+        CharwiseDoubleArrayAhoCorasickBuilder::new()
+            .match_kind(MatchKind::LeftmostLongest)
+            .build(Vec::<String>::new());
+    assert!(pma.is_err());
 }
 
 #[test]
 fn test_duplicate_patterns_with_matchkind_leftmost_longest() {
-    assert!(CharwiseDoubleArrayAhoCorasickBuilder::new()
-        .match_kind(MatchKind::LeftmostLongest)
-        .build(["abc", "123", "abc",])
-        .is_err());
+    let pma: Result<CharwiseDoubleArrayAhoCorasick<usize>, _> =
+        CharwiseDoubleArrayAhoCorasickBuilder::new()
+            .match_kind(MatchKind::LeftmostLongest)
+            .build(["abc", "123", "abc"]);
+    assert!(pma.is_err());
 }
 
 #[test]
 fn test_empty_pattern_with_matchkind_leftmost_first() {
-    assert!(CharwiseDoubleArrayAhoCorasickBuilder::new()
-        .match_kind(MatchKind::LeftmostFirst)
-        .build([""])
-        .is_err());
+    let pma: Result<CharwiseDoubleArrayAhoCorasick<usize>, _> =
+        CharwiseDoubleArrayAhoCorasickBuilder::new()
+            .match_kind(MatchKind::LeftmostFirst)
+            .build([""]);
+    assert!(pma.is_err());
 }
 
 #[test]
 fn test_empty_set_with_matchkind_leftmost_first() {
-    assert!(CharwiseDoubleArrayAhoCorasickBuilder::new()
-        .match_kind(MatchKind::LeftmostFirst)
-        .build(Vec::<String>::new())
-        .is_err());
+    let pma: Result<CharwiseDoubleArrayAhoCorasick<usize>, _> =
+        CharwiseDoubleArrayAhoCorasickBuilder::new()
+            .match_kind(MatchKind::LeftmostFirst)
+            .build(Vec::<String>::new());
+    assert!(pma.is_err());
 }
 
 #[test]
 fn test_duplicate_patterns_with_matchkind_leftmost_first() {
-    assert!(CharwiseDoubleArrayAhoCorasickBuilder::new()
-        .match_kind(MatchKind::LeftmostFirst)
-        .build(["abc", "123", "abc",])
-        .is_err());
+    let pma: Result<CharwiseDoubleArrayAhoCorasick<usize>, _> =
+        CharwiseDoubleArrayAhoCorasickBuilder::new()
+            .match_kind(MatchKind::LeftmostFirst)
+            .build(["abc", "123", "abc"]);
+    assert!(pma.is_err());
 }
 
 #[test]
 fn test_empty_pattern_with_matchkind_standard() {
-    assert!(CharwiseDoubleArrayAhoCorasickBuilder::new()
-        .match_kind(MatchKind::Standard)
-        .build([""])
-        .is_err());
+    let pma: Result<CharwiseDoubleArrayAhoCorasick<usize>, _> =
+        CharwiseDoubleArrayAhoCorasickBuilder::new()
+            .match_kind(MatchKind::Standard)
+            .build([""]);
+    assert!(pma.is_err());
 }
 
 #[test]
 fn test_empty_set_with_matchkind_standard() {
-    assert!(CharwiseDoubleArrayAhoCorasickBuilder::new()
-        .match_kind(MatchKind::Standard)
-        .build(Vec::<String>::new())
-        .is_err());
+    let pma: Result<CharwiseDoubleArrayAhoCorasick<usize>, _> =
+        CharwiseDoubleArrayAhoCorasickBuilder::new()
+            .match_kind(MatchKind::Standard)
+            .build(Vec::<String>::new());
+    assert!(pma.is_err());
 }
 
 #[test]
 fn test_duplicate_patterns_with_matchkind_standard() {
-    assert!(CharwiseDoubleArrayAhoCorasickBuilder::new()
-        .match_kind(MatchKind::Standard)
-        .build(["abc", "123", "abc"])
-        .is_err());
+    let pma: Result<CharwiseDoubleArrayAhoCorasick<usize>, _> =
+        CharwiseDoubleArrayAhoCorasickBuilder::new()
+            .match_kind(MatchKind::Standard)
+            .build(["abc", "123", "abc"]);
+    assert!(pma.is_err());
 }

--- a/tests/invalid_pattern_test.rs
+++ b/tests/invalid_pattern_test.rs
@@ -2,87 +2,87 @@ use daachorse::{DoubleArrayAhoCorasick, DoubleArrayAhoCorasickBuilder, MatchKind
 
 #[test]
 fn test_empty_pattern() {
-    assert!(DoubleArrayAhoCorasick::new([""]).is_err());
+    assert!(DoubleArrayAhoCorasick::<usize>::new([""]).is_err());
 }
 
 #[test]
 fn test_empty_set() {
-    assert!(DoubleArrayAhoCorasick::new(Vec::<String>::new()).is_err());
+    assert!(DoubleArrayAhoCorasick::<usize>::new(Vec::<String>::new()).is_err());
 }
 
 #[test]
 fn test_duplicate_patterns() {
-    assert!(DoubleArrayAhoCorasick::new(["abc", "123", "abc",]).is_err());
+    assert!(DoubleArrayAhoCorasick::<usize>::new(["abc", "123", "abc",]).is_err());
 }
 
 #[test]
 fn test_empty_pattern_with_matchkind_leftmost_longest() {
-    assert!(DoubleArrayAhoCorasickBuilder::new()
+    let pma: Result<DoubleArrayAhoCorasick<usize>, _> = DoubleArrayAhoCorasickBuilder::new()
         .match_kind(MatchKind::LeftmostLongest)
-        .build([""])
-        .is_err());
+        .build([""]);
+    assert!(pma.is_err());
 }
 
 #[test]
 fn test_empty_set_with_matchkind_leftmost_longest() {
-    assert!(DoubleArrayAhoCorasickBuilder::new()
+    let pma: Result<DoubleArrayAhoCorasick<usize>, _> = DoubleArrayAhoCorasickBuilder::new()
         .match_kind(MatchKind::LeftmostLongest)
-        .build(Vec::<String>::new())
-        .is_err());
+        .build(Vec::<String>::new());
+    assert!(pma.is_err());
 }
 
 #[test]
 fn test_duplicate_patterns_with_matchkind_leftmost_longest() {
-    assert!(DoubleArrayAhoCorasickBuilder::new()
+    let pma: Result<DoubleArrayAhoCorasick<usize>, _> = DoubleArrayAhoCorasickBuilder::new()
         .match_kind(MatchKind::LeftmostLongest)
-        .build(["abc", "123", "abc",])
-        .is_err());
+        .build(["abc", "123", "abc"]);
+    assert!(pma.is_err());
 }
 
 #[test]
 fn test_empty_pattern_with_matchkind_leftmost_first() {
-    assert!(DoubleArrayAhoCorasickBuilder::new()
+    let pma: Result<DoubleArrayAhoCorasick<usize>, _> = DoubleArrayAhoCorasickBuilder::new()
         .match_kind(MatchKind::LeftmostFirst)
-        .build([""])
-        .is_err());
+        .build([""]);
+    assert!(pma.is_err());
 }
 
 #[test]
 fn test_empty_set_with_matchkind_leftmost_first() {
-    assert!(DoubleArrayAhoCorasickBuilder::new()
+    let pma: Result<DoubleArrayAhoCorasick<usize>, _> = DoubleArrayAhoCorasickBuilder::new()
         .match_kind(MatchKind::LeftmostFirst)
-        .build(Vec::<String>::new())
-        .is_err());
+        .build(Vec::<String>::new());
+    assert!(pma.is_err());
 }
 
 #[test]
 fn test_duplicate_patterns_with_matchkind_leftmost_first() {
-    assert!(DoubleArrayAhoCorasickBuilder::new()
+    let pma: Result<DoubleArrayAhoCorasick<usize>, _> = DoubleArrayAhoCorasickBuilder::new()
         .match_kind(MatchKind::LeftmostFirst)
-        .build(["abc", "123", "abc",])
-        .is_err());
+        .build(["abc", "123", "abc"]);
+    assert!(pma.is_err());
 }
 
 #[test]
 fn test_empty_pattern_with_matchkind_standard() {
-    assert!(DoubleArrayAhoCorasickBuilder::new()
+    let pma: Result<DoubleArrayAhoCorasick<usize>, _> = DoubleArrayAhoCorasickBuilder::new()
         .match_kind(MatchKind::Standard)
-        .build([""])
-        .is_err());
+        .build([""]);
+    assert!(pma.is_err());
 }
 
 #[test]
 fn test_empty_set_with_matchkind_standard() {
-    assert!(DoubleArrayAhoCorasickBuilder::new()
+    let pma: Result<DoubleArrayAhoCorasick<usize>, _> = DoubleArrayAhoCorasickBuilder::new()
         .match_kind(MatchKind::Standard)
-        .build(Vec::<String>::new())
-        .is_err());
+        .build(Vec::<String>::new());
+    assert!(pma.is_err());
 }
 
 #[test]
 fn test_duplicate_patterns_with_matchkind_standard() {
-    assert!(DoubleArrayAhoCorasickBuilder::new()
+    let pma: Result<DoubleArrayAhoCorasick<usize>, _> = DoubleArrayAhoCorasickBuilder::new()
         .match_kind(MatchKind::Standard)
-        .build(["abc", "123", "abc"])
-        .is_err());
+        .build(["abc", "123", "abc"]);
+    assert!(pma.is_err());
 }

--- a/tests/matchkind_mismatch_charwise_test.rs
+++ b/tests/matchkind_mismatch_charwise_test.rs
@@ -1,9 +1,9 @@
-use daachorse::{CharwiseDoubleArrayAhoCorasickBuilder, MatchKind};
+use daachorse::{CharwiseDoubleArrayAhoCorasick, CharwiseDoubleArrayAhoCorasickBuilder, MatchKind};
 
 #[test]
 #[should_panic]
 fn test_find_iter_with_leftmost_longest() {
-    let pma = CharwiseDoubleArrayAhoCorasickBuilder::new()
+    let pma: CharwiseDoubleArrayAhoCorasick<usize> = CharwiseDoubleArrayAhoCorasickBuilder::new()
         .match_kind(MatchKind::LeftmostLongest)
         .build(["pattern"])
         .unwrap();
@@ -13,7 +13,7 @@ fn test_find_iter_with_leftmost_longest() {
 #[test]
 #[should_panic]
 fn test_find_iter_with_leftmost_first() {
-    let pma = CharwiseDoubleArrayAhoCorasickBuilder::new()
+    let pma: CharwiseDoubleArrayAhoCorasick<usize> = CharwiseDoubleArrayAhoCorasickBuilder::new()
         .match_kind(MatchKind::LeftmostFirst)
         .build(["pattern"])
         .unwrap();
@@ -23,7 +23,7 @@ fn test_find_iter_with_leftmost_first() {
 #[test]
 #[should_panic]
 fn test_find_overlapping_iter_with_leftmost_longest() {
-    let pma = CharwiseDoubleArrayAhoCorasickBuilder::new()
+    let pma: CharwiseDoubleArrayAhoCorasick<usize> = CharwiseDoubleArrayAhoCorasickBuilder::new()
         .match_kind(MatchKind::LeftmostLongest)
         .build(["pattern"])
         .unwrap();
@@ -33,7 +33,7 @@ fn test_find_overlapping_iter_with_leftmost_longest() {
 #[test]
 #[should_panic]
 fn test_find_overlapping_iter_with_leftmost_first() {
-    let pma = CharwiseDoubleArrayAhoCorasickBuilder::new()
+    let pma: CharwiseDoubleArrayAhoCorasick<usize> = CharwiseDoubleArrayAhoCorasickBuilder::new()
         .match_kind(MatchKind::LeftmostFirst)
         .build(["pattern"])
         .unwrap();
@@ -43,7 +43,7 @@ fn test_find_overlapping_iter_with_leftmost_first() {
 #[test]
 #[should_panic]
 fn test_find_overlapping_no_suffix_iter_with_leftmost_longest() {
-    let pma = CharwiseDoubleArrayAhoCorasickBuilder::new()
+    let pma: CharwiseDoubleArrayAhoCorasick<usize> = CharwiseDoubleArrayAhoCorasickBuilder::new()
         .match_kind(MatchKind::LeftmostLongest)
         .build(["pattern"])
         .unwrap();
@@ -53,7 +53,7 @@ fn test_find_overlapping_no_suffix_iter_with_leftmost_longest() {
 #[test]
 #[should_panic]
 fn test_find_overlapping_no_suffix_iter_with_leftmost_first() {
-    let pma = CharwiseDoubleArrayAhoCorasickBuilder::new()
+    let pma: CharwiseDoubleArrayAhoCorasick<usize> = CharwiseDoubleArrayAhoCorasickBuilder::new()
         .match_kind(MatchKind::LeftmostFirst)
         .build(["pattern"])
         .unwrap();
@@ -63,7 +63,7 @@ fn test_find_overlapping_no_suffix_iter_with_leftmost_first() {
 #[test]
 #[should_panic]
 fn test_leftmost_find_iter_with_standard() {
-    let pma = CharwiseDoubleArrayAhoCorasickBuilder::new()
+    let pma: CharwiseDoubleArrayAhoCorasick<usize> = CharwiseDoubleArrayAhoCorasickBuilder::new()
         .match_kind(MatchKind::Standard)
         .build(["pattern"])
         .unwrap();

--- a/tests/matchkind_mismatch_test.rs
+++ b/tests/matchkind_mismatch_test.rs
@@ -1,9 +1,9 @@
-use daachorse::{DoubleArrayAhoCorasickBuilder, MatchKind};
+use daachorse::{DoubleArrayAhoCorasick, DoubleArrayAhoCorasickBuilder, MatchKind};
 
 #[test]
 #[should_panic]
 fn test_find_iter_with_leftmost_longest() {
-    let pma = DoubleArrayAhoCorasickBuilder::new()
+    let pma: DoubleArrayAhoCorasick<u32> = DoubleArrayAhoCorasickBuilder::new()
         .match_kind(MatchKind::LeftmostLongest)
         .build(["pattern"])
         .unwrap();
@@ -13,7 +13,7 @@ fn test_find_iter_with_leftmost_longest() {
 #[test]
 #[should_panic]
 fn test_find_iter_with_leftmost_first() {
-    let pma = DoubleArrayAhoCorasickBuilder::new()
+    let pma: DoubleArrayAhoCorasick<u32> = DoubleArrayAhoCorasickBuilder::new()
         .match_kind(MatchKind::LeftmostFirst)
         .build(["pattern"])
         .unwrap();
@@ -23,7 +23,7 @@ fn test_find_iter_with_leftmost_first() {
 #[test]
 #[should_panic]
 fn test_find_overlapping_iter_with_leftmost_longest() {
-    let pma = DoubleArrayAhoCorasickBuilder::new()
+    let pma: DoubleArrayAhoCorasick<u32> = DoubleArrayAhoCorasickBuilder::new()
         .match_kind(MatchKind::LeftmostLongest)
         .build(["pattern"])
         .unwrap();
@@ -33,7 +33,7 @@ fn test_find_overlapping_iter_with_leftmost_longest() {
 #[test]
 #[should_panic]
 fn test_find_overlapping_iter_with_leftmost_first() {
-    let pma = DoubleArrayAhoCorasickBuilder::new()
+    let pma: DoubleArrayAhoCorasick<u32> = DoubleArrayAhoCorasickBuilder::new()
         .match_kind(MatchKind::LeftmostFirst)
         .build(["pattern"])
         .unwrap();
@@ -43,7 +43,7 @@ fn test_find_overlapping_iter_with_leftmost_first() {
 #[test]
 #[should_panic]
 fn test_find_overlapping_no_suffix_iter_with_leftmost_longest() {
-    let pma = DoubleArrayAhoCorasickBuilder::new()
+    let pma: DoubleArrayAhoCorasick<u32> = DoubleArrayAhoCorasickBuilder::new()
         .match_kind(MatchKind::LeftmostLongest)
         .build(["pattern"])
         .unwrap();
@@ -53,7 +53,7 @@ fn test_find_overlapping_no_suffix_iter_with_leftmost_longest() {
 #[test]
 #[should_panic]
 fn test_find_overlapping_no_suffix_iter_with_leftmost_first() {
-    let pma = DoubleArrayAhoCorasickBuilder::new()
+    let pma: DoubleArrayAhoCorasick<u32> = DoubleArrayAhoCorasickBuilder::new()
         .match_kind(MatchKind::LeftmostFirst)
         .build(["pattern"])
         .unwrap();
@@ -63,7 +63,7 @@ fn test_find_overlapping_no_suffix_iter_with_leftmost_first() {
 #[test]
 #[should_panic]
 fn test_leftmost_find_iter_with_standard() {
-    let pma = DoubleArrayAhoCorasickBuilder::new()
+    let pma: DoubleArrayAhoCorasick<u32> = DoubleArrayAhoCorasickBuilder::new()
         .match_kind(MatchKind::Standard)
         .build(["pattern"])
         .unwrap();


### PR DESCRIPTION
This branch uses generics for output values rather than a deterministic type.

When constructing an automaton, this change allows users to specify any type that implements `Copy+Default` as values in `with_values()`. 
Also, when building with `new()`, users can specify any type that implements `Copy+Default+TryFrom<usize>`. If the conversion from `usize` fails, a default value will be assigned.
If the type implements `Serializable`, the automaton can be serialized.