### PR TITLE
Remove the trait bound Default from V

### DIFF
--- a/src/bytewise.rs
+++ b/src/bytewise.rs
@@ -59,8 +59,7 @@ pub struct DoubleArrayAhoCorasick<V> {
 
 impl<V> DoubleArrayAhoCorasick<V> {
     /// Creates a new [`DoubleArrayAhoCorasick`] from input patterns. The value `i` is
-    /// automatically associated with `patterns[i]`. If the conversion from the index value to the
-    /// specified type `V` fails, [`Default::default()`] is assigned instead.
+    /// automatically associated with `patterns[i]`.
     ///
     /// # Arguments
     ///
@@ -72,6 +71,7 @@ impl<V> DoubleArrayAhoCorasick<V> {
     ///   - `patterns` is empty,
     ///   - `patterns` contains entries of length zero,
     ///   - `patterns` contains duplicate entries,
+    ///   - the conversion from the index `i` to the specified type `V` fails,
     ///   - the scale of `patterns` exceeds the expected one, or
     ///   - the scale of the resulting automaton exceeds the expected one.
     ///
@@ -97,7 +97,7 @@ impl<V> DoubleArrayAhoCorasick<V> {
     where
         I: IntoIterator<Item = P>,
         P: AsRef<[u8]>,
-        V: Copy + Default + TryFrom<usize>,
+        V: Copy + TryFrom<usize>,
     {
         DoubleArrayAhoCorasickBuilder::new().build(patterns)
     }
@@ -142,7 +142,7 @@ impl<V> DoubleArrayAhoCorasick<V> {
     where
         I: IntoIterator<Item = (P, V)>,
         P: AsRef<[u8]>,
-        V: Copy + Default,
+        V: Copy,
     {
         DoubleArrayAhoCorasickBuilder::new().build_with_values(patvals)
     }
@@ -534,7 +534,7 @@ impl<V> DoubleArrayAhoCorasick<V> {
     /// let patterns = vec!["bcd", "ab", "a"];
     /// let pma = DoubleArrayAhoCorasick::<u32>::new(patterns).unwrap();
     ///
-    /// assert_eq!(3120, pma.heap_bytes());
+    /// assert_eq!(3108, pma.heap_bytes());
     /// ```
     #[must_use]
     pub fn heap_bytes(&self) -> usize {

--- a/src/bytewise/iter.rs
+++ b/src/bytewise/iter.rs
@@ -71,7 +71,7 @@ where
                 let out = unsafe {
                     self.pma
                         .outputs
-                        .get_unchecked(usize::from_u32(output_pos.get()))
+                        .get_unchecked(usize::from_u32(output_pos.get() - 1))
                 };
                 return Some(Match {
                     length: usize::from_u32(out.length()),
@@ -108,7 +108,7 @@ where
             let out = unsafe {
                 self.pma
                     .outputs
-                    .get_unchecked(usize::from_u32(output_pos.get()))
+                    .get_unchecked(usize::from_u32(output_pos.get() - 1))
             };
             self.output_pos = out.parent();
             return Some(Match {
@@ -133,7 +133,7 @@ where
                 let out = unsafe {
                     self.pma
                         .outputs
-                        .get_unchecked(usize::from_u32(output_pos.get()))
+                        .get_unchecked(usize::from_u32(output_pos.get() - 1))
                 };
                 self.output_pos = out.parent();
                 return Some(Match {
@@ -178,7 +178,7 @@ where
                 let out = unsafe {
                     self.pma
                         .outputs
-                        .get_unchecked(usize::from_u32(output_pos.get()))
+                        .get_unchecked(usize::from_u32(output_pos.get() - 1))
                 };
                 return Some(Match {
                     length: usize::from_u32(out.length()),
@@ -225,7 +225,7 @@ where
                     let out = unsafe {
                         self.pma
                             .outputs
-                            .get_unchecked(usize::from_u32(output_pos.get()))
+                            .get_unchecked(usize::from_u32(output_pos.get() - 1))
                     };
                     return Some(Match {
                         length: usize::from_u32(out.length()),
@@ -252,7 +252,7 @@ where
             let out = unsafe {
                 self.pma
                     .outputs
-                    .get_unchecked(usize::from_u32(output_pos.get()))
+                    .get_unchecked(usize::from_u32(output_pos.get() - 1))
             };
             Match {
                 length: usize::from_u32(out.length()),

--- a/src/charwise.rs
+++ b/src/charwise.rs
@@ -65,8 +65,7 @@ pub struct CharwiseDoubleArrayAhoCorasick<V> {
 
 impl<V> CharwiseDoubleArrayAhoCorasick<V> {
     /// Creates a new [`CharwiseDoubleArrayAhoCorasick`] from input patterns. The value `i` is
-    /// automatically associated with `patterns[i]`. If the conversion from the index value to the
-    /// specified type `V` fails, [`Default::default()`] is assigned instead.
+    /// automatically associated with `patterns[i]`.
     ///
     /// # Arguments
     ///
@@ -78,6 +77,7 @@ impl<V> CharwiseDoubleArrayAhoCorasick<V> {
     ///   - `patterns` is empty,
     ///   - `patterns` contains entries of length zero,
     ///   - `patterns` contains duplicate entries,
+    ///   - the conversion from the index `i` to the specified type `V` fails,
     ///   - the scale of `patterns` exceeds the expected one, or
     ///   - the scale of the resulting automaton exceeds the expected one.
     ///
@@ -103,7 +103,7 @@ impl<V> CharwiseDoubleArrayAhoCorasick<V> {
     where
         I: IntoIterator<Item = P>,
         P: AsRef<str>,
-        V: Copy + Default + TryFrom<usize>,
+        V: Copy + TryFrom<usize>,
     {
         CharwiseDoubleArrayAhoCorasickBuilder::new().build(patterns)
     }
@@ -120,7 +120,6 @@ impl<V> CharwiseDoubleArrayAhoCorasick<V> {
     ///   - `patvals` is empty,
     ///   - `patvals` contains patterns of length zero,
     ///   - `patvals` contains duplicate patterns,
-    ///   - `patvals` contains invalid values,
     ///   - the scale of `patvals` exceeds the expected one, or
     ///   - the scale of the resulting automaton exceeds the expected one.
     ///
@@ -146,7 +145,7 @@ impl<V> CharwiseDoubleArrayAhoCorasick<V> {
     where
         I: IntoIterator<Item = (P, V)>,
         P: AsRef<str>,
-        V: Copy + Default,
+        V: Copy,
     {
         CharwiseDoubleArrayAhoCorasickBuilder::new().build_with_values(patvals)
     }
@@ -587,7 +586,7 @@ impl<V> CharwiseDoubleArrayAhoCorasick<V> {
     /// let patterns = vec!["bcd", "ab", "a"];
     /// let pma = CharwiseDoubleArrayAhoCorasick::<u32>::new(patterns).unwrap();
     ///
-    /// assert_eq!(580, pma.heap_bytes());
+    /// assert_eq!(568, pma.heap_bytes());
     /// ```
     #[must_use]
     pub fn heap_bytes(&self) -> usize {

--- a/src/charwise/builder.rs
+++ b/src/charwise/builder.rs
@@ -94,8 +94,7 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
     }
 
     /// Builds and returns a new [`CharwiseDoubleArrayAhoCorasick`] from input patterns. The value
-    /// `i` is automatically associated with `patterns[i]`. If the conversion from the index value to the
-    /// specified type `V` fails, [`Default::default()`] is assigned instead.
+    /// `i` is automatically associated with `patterns[i]`.
     ///
     /// # Arguments
     ///
@@ -107,6 +106,7 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
     ///   - `patterns` is empty,
     ///   - `patterns` contains entries of length zero,
     ///   - `patterns` contains duplicate entries,
+    ///   - the conversion from the index `i` to the specified type `V` fails,
     ///   - the scale of `patterns` exceeds the expected one, or
     ///   - the scale of the resulting automaton exceeds the expected one.
     ///
@@ -134,14 +134,16 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
     where
         I: IntoIterator<Item = P>,
         P: AsRef<str>,
-        V: Copy + Default + TryFrom<usize>,
+        V: Copy + TryFrom<usize>,
     {
         // The following code implicitly replaces large indices with 0,
         // but build_with_values() returns an error variant for such iterators.
-        let patvals = patterns
+        let patvals: Vec<_> = patterns
             .into_iter()
             .enumerate()
-            .map(|(i, p)| (p, V::try_from(i).unwrap_or_default()));
+            .map(|(i, p)| V::try_from(i).map(|i| (p, i)))
+            .collect::<Result<_, _>>()
+            .map_err(|_| DaachorseError::invalid_conversion("index", "V"))?;
         self.build_with_values(patvals)
     }
 
@@ -157,7 +159,6 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
     ///   - `patvals` is empty,
     ///   - `patvals` contains patterns of length zero,
     ///   - `patvals` contains duplicate patterns,
-    ///   - `patvals` contains invalid values,
     ///   - the scale of `patvals` exceeds the expected one, or
     ///   - the scale of the resulting automaton exceeds the expected one.
     ///
@@ -188,7 +189,7 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
     where
         I: IntoIterator<Item = (P, V)>,
         P: AsRef<str>,
-        V: Copy + Default,
+        V: Copy,
     {
         let nfa = self.build_original_nfa_and_mapper(patvals)?;
 
@@ -214,7 +215,7 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
     where
         I: IntoIterator<Item = (P, V)>,
         P: AsRef<str>,
-        V: Copy + Default,
+        V: Copy,
     {
         let mut nfa = CharwiseNfaBuilder::new(self.match_kind);
         let mut freqs = vec![];

--- a/src/charwise/iter.rs
+++ b/src/charwise/iter.rs
@@ -142,7 +142,7 @@ where
             let out = unsafe {
                 self.pma
                     .outputs
-                    .get_unchecked(usize::from_u32(output_pos.get()))
+                    .get_unchecked(usize::from_u32(output_pos.get() - 1))
             };
             self.output_pos = out.parent();
             return Some(Match {
@@ -169,7 +169,7 @@ where
                 let out = unsafe {
                     self.pma
                         .outputs
-                        .get_unchecked(usize::from_u32(output_pos.get()))
+                        .get_unchecked(usize::from_u32(output_pos.get() - 1))
                 };
                 self.output_pos = out.parent();
                 return Some(Match {
@@ -208,7 +208,7 @@ where
                 let out = unsafe {
                     self.pma
                         .outputs
-                        .get_unchecked(usize::from_u32(output_pos.get()))
+                        .get_unchecked(usize::from_u32(output_pos.get() - 1))
                 };
                 return Some(Match {
                     length: usize::from_u32(out.length()),
@@ -245,7 +245,7 @@ where
                 let out = unsafe {
                     self.pma
                         .outputs
-                        .get_unchecked(usize::from_u32(output_pos.get()))
+                        .get_unchecked(usize::from_u32(output_pos.get() - 1))
                 };
                 return Some(Match {
                     length: usize::from_u32(out.length()),
@@ -284,7 +284,7 @@ where
                     let out = unsafe {
                         self.pma
                             .outputs
-                            .get_unchecked(usize::from_u32(output_pos.get()))
+                            .get_unchecked(usize::from_u32(output_pos.get() - 1))
                     };
                     return Some(Match {
                         length: usize::from_u32(out.length()),
@@ -312,7 +312,7 @@ where
             let out = unsafe {
                 self.pma
                     .outputs
-                    .get_unchecked(usize::from_u32(output_pos.get()))
+                    .get_unchecked(usize::from_u32(output_pos.get() - 1))
             };
             Match {
                 length: usize::from_u32(out.length()),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -16,6 +16,9 @@ pub enum DaachorseError {
 
     /// Contains [`AutomatonScaleError`].
     AutomatonScale(AutomatonScaleError),
+
+    /// Contains [`InvalidConversionError`].
+    InvalidConversion(InvalidConversionError),
 }
 
 impl fmt::Display for DaachorseError {
@@ -24,6 +27,7 @@ impl fmt::Display for DaachorseError {
             Self::InvalidArgument(e) => e.fmt(f),
             Self::DuplicatePattern(e) => e.fmt(f),
             Self::AutomatonScale(e) => e.fmt(f),
+            Self::InvalidConversion(e) => e.fmt(f),
         }
     }
 }
@@ -39,6 +43,10 @@ impl DaachorseError {
 
     pub(crate) const fn automaton_scale(arg: &'static str, max_value: u32) -> Self {
         Self::AutomatonScale(AutomatonScaleError { arg, max_value })
+    }
+
+    pub(crate) const fn invalid_conversion(arg: &'static str, target: &'static str) -> Self {
+        Self::InvalidConversion(InvalidConversionError { arg, target })
     }
 }
 
@@ -94,6 +102,26 @@ impl fmt::Display for AutomatonScaleError {
             f,
             "AutomatonScaleError: {} must be <= {}",
             self.arg, self.max_value
+        )
+    }
+}
+
+/// Error used when the conversion fails.
+#[derive(Debug)]
+pub struct InvalidConversionError {
+    /// Name of the argument.
+    arg: &'static str,
+
+    /// Target type.
+    target: &'static str,
+}
+
+impl fmt::Display for InvalidConversionError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "InvalidConversionError: {} cannot be converted to {}",
+            self.arg, self.target
         )
     }
 }

--- a/src/nfa_builder.rs
+++ b/src/nfa_builder.rs
@@ -62,7 +62,7 @@ pub struct NfaBuilder<L, V> {
 impl<L, V> NfaBuilder<L, V>
 where
     L: EdgeLabel,
-    V: Copy + Default,
+    V: Copy,
 {
     pub(crate) fn new(match_kind: MatchKind) -> Self {
         Self {
@@ -212,13 +212,10 @@ where
         // But, there is no problem since Daachorse does not allow an empty pattern.
         debug_assert_ne!(q[0], ROOT_STATE_ID);
 
-        // Adds a dummy output so that the output_pos is positive.
-        self.outputs.push(Output::new(V::default(), 0, None));
-
         for &state_id in q {
             let s = &mut self.states[usize::from_u32(state_id)].borrow_mut();
             if let Some(output) = s.output {
-                s.output_pos = NonZeroU32::new(u32::try_from(self.outputs.len()).unwrap());
+                s.output_pos = NonZeroU32::new(u32::try_from(self.outputs.len() + 1).unwrap());
                 let parent = self.states[usize::from_u32(s.fail)].borrow().output_pos;
                 self.outputs
                     .push(Output::new(output.0, output.1.get(), parent));


### PR DESCRIPTION
This branch removes the trait bound `Default` from `V`.
This change allows users to specify more types, including pointer types (raw pointers and references).

I do not observe a significant performance impact with this change.