### PR TITLE
Rename some functions following API guidelines

### DIFF
--- a/src/bytewise.rs
+++ b/src/bytewise.rs
@@ -651,7 +651,7 @@ impl<V> DoubleArrayAhoCorasick<V> {
     ///
     /// `state_id` must be smaller than the length of states.
     #[inline(always)]
-    unsafe fn get_child_index_unchecked(&self, state_id: u32, c: u8) -> Option<u32> {
+    unsafe fn child_index_unchecked(&self, state_id: u32, c: u8) -> Option<u32> {
         // child_idx is always smaller than states.len() because
         //  - states.len() is 256 * k for some integer k, and
         //  - base() returns smaller than states.len() when it is Some.
@@ -669,11 +669,11 @@ impl<V> DoubleArrayAhoCorasick<V> {
     ///
     /// `state_id` must be smaller than the length of states.
     #[inline(always)]
-    unsafe fn get_next_state_id_unchecked(&self, mut state_id: u32, c: u8) -> u32 {
+    unsafe fn next_state_id_unchecked(&self, mut state_id: u32, c: u8) -> u32 {
         // In the loop, state_id is always set to values smaller than states.len(),
-        // because get_child_index_unchecked() and fail() return such values.
+        // because child_index_unchecked() and fail() return such values.
         loop {
-            if let Some(state_id) = self.get_child_index_unchecked(state_id, c) {
+            if let Some(state_id) = self.child_index_unchecked(state_id, c) {
                 return state_id;
             }
             if state_id == ROOT_STATE_IDX {
@@ -687,11 +687,11 @@ impl<V> DoubleArrayAhoCorasick<V> {
     ///
     /// `state_id` must be smaller than the length of states.
     #[inline(always)]
-    unsafe fn get_next_state_id_leftmost_unchecked(&self, mut state_id: u32, c: u8) -> u32 {
+    unsafe fn next_state_id_leftmost_unchecked(&self, mut state_id: u32, c: u8) -> u32 {
         // In the loop, state_id is always set to values smaller than states.len(),
-        // because get_child_index_unchecked() and fail() return such values.
+        // because child_index_unchecked() and fail() return such values.
         loop {
-            if let Some(state_id) = self.get_child_index_unchecked(state_id, c) {
+            if let Some(state_id) = self.child_index_unchecked(state_id, c) {
                 return state_id;
             }
             if state_id == ROOT_STATE_IDX {

--- a/src/bytewise/iter.rs
+++ b/src/bytewise/iter.rs
@@ -58,8 +58,8 @@ where
         let mut state_id = ROOT_STATE_IDX;
         for (pos, c) in self.haystack.by_ref() {
             // state_id is always smaller than self.pma.states.len() because
-            // self.pma.get_next_state_id_unchecked() ensures to return such a value.
-            state_id = unsafe { self.pma.get_next_state_id_unchecked(state_id, c) };
+            // self.pma.next_state_id_unchecked() ensures to return such a value.
+            state_id = unsafe { self.pma.next_state_id_unchecked(state_id, c) };
             if let Some(output_pos) = unsafe {
                 self.pma
                     .states
@@ -119,8 +119,8 @@ where
         }
         for (pos, c) in self.haystack.by_ref() {
             // self.state_id is always smaller than self.pma.states.len() because
-            // self.pma.get_next_state_id_unchecked() ensures to return such a value.
-            self.state_id = unsafe { self.pma.get_next_state_id_unchecked(self.state_id, c) };
+            // self.pma.next_state_id_unchecked() ensures to return such a value.
+            self.state_id = unsafe { self.pma.next_state_id_unchecked(self.state_id, c) };
             if let Some(output_pos) = unsafe {
                 self.pma
                     .states
@@ -165,8 +165,8 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         for (pos, c) in self.haystack.by_ref() {
             // self.state_id is always smaller than self.pma.states.len() because
-            // self.pma.get_next_state_id_unchecked() ensures to return such a value.
-            self.state_id = unsafe { self.pma.get_next_state_id_unchecked(self.state_id, c) };
+            // self.pma.next_state_id_unchecked() ensures to return such a value.
+            self.state_id = unsafe { self.pma.next_state_id_unchecked(self.state_id, c) };
             if let Some(output_pos) = unsafe {
                 self.pma
                     .states
@@ -216,8 +216,8 @@ where
         let haystack = self.haystack.as_ref();
         for (pos, &c) in haystack.iter().enumerate().skip(self.pos) {
             // state_id is always smaller than self.pma.states.len() because
-            // self.pma.get_next_state_id_leftmost_unchecked() ensures to return such a value.
-            state_id = unsafe { self.pma.get_next_state_id_leftmost_unchecked(state_id, c) };
+            // self.pma.next_state_id_leftmost_unchecked() ensures to return such a value.
+            state_id = unsafe { self.pma.next_state_id_leftmost_unchecked(state_id, c) };
             if state_id == ROOT_STATE_IDX {
                 if let Some(output_pos) = last_output_pos {
                     // last_output_pos is always smaller than self.pma.outputs.len() because
@@ -234,7 +234,7 @@ where
                     });
                 }
             // state_id is always smaller than self.pma.states.len() because
-            // self.pma.get_next_state_id_leftmost_unchecked() ensures to return such a value.
+            // self.pma.next_state_id_leftmost_unchecked() ensures to return such a value.
             } else if let Some(output_pos) = unsafe {
                 self.pma
                     .states

--- a/src/charwise.rs
+++ b/src/charwise.rs
@@ -692,7 +692,7 @@ impl<V> CharwiseDoubleArrayAhoCorasick<V> {
     /// `state_id` must be smaller than the length of states.
     #[allow(clippy::cast_possible_wrap)]
     #[inline(always)]
-    unsafe fn get_child_index_unchecked(&self, state_id: u32, mapped_c: u32) -> Option<u32> {
+    unsafe fn child_index_unchecked(&self, state_id: u32, mapped_c: u32) -> Option<u32> {
         let base = self
             .states
             .get_unchecked(usize::from_u32(state_id))
@@ -718,10 +718,10 @@ impl<V> CharwiseDoubleArrayAhoCorasick<V> {
     ///
     /// `state_id` must be smaller than the length of states.
     #[inline(always)]
-    unsafe fn get_next_state_id_unchecked(&self, mut state_id: u32, c: char) -> u32 {
+    unsafe fn next_state_id_unchecked(&self, mut state_id: u32, c: char) -> u32 {
         if let Some(mapped_c) = self.mapper.get(c) {
             loop {
-                if let Some(state_id) = self.get_child_index_unchecked(state_id, mapped_c) {
+                if let Some(state_id) = self.child_index_unchecked(state_id, mapped_c) {
                     return state_id;
                 }
                 if state_id == ROOT_STATE_IDX {
@@ -738,10 +738,10 @@ impl<V> CharwiseDoubleArrayAhoCorasick<V> {
     ///
     /// `state_id` must be smaller than the length of states.
     #[inline(always)]
-    unsafe fn get_next_state_id_leftmost_unchecked(&self, mut state_id: u32, c: char) -> u32 {
+    unsafe fn next_state_id_leftmost_unchecked(&self, mut state_id: u32, c: char) -> u32 {
         if let Some(mapped_c) = self.mapper.get(c) {
             loop {
-                if let Some(state_id) = self.get_child_index_unchecked(state_id, mapped_c) {
+                if let Some(state_id) = self.child_index_unchecked(state_id, mapped_c) {
                     return state_id;
                 }
                 if state_id == ROOT_STATE_IDX {

--- a/src/charwise/iter.rs
+++ b/src/charwise/iter.rs
@@ -156,8 +156,8 @@ where
             self.pos = pos;
 
             // self.state_id is always smaller than self.pma.states.len() because
-            // self.pma.get_next_state_id_unchecked() ensures to return such a value.
-            self.state_id = unsafe { self.pma.get_next_state_id_unchecked(self.state_id, c) };
+            // self.pma.next_state_id_unchecked() ensures to return such a value.
+            self.state_id = unsafe { self.pma.next_state_id_unchecked(self.state_id, c) };
             if let Some(output_pos) = unsafe {
                 self.pma
                     .states
@@ -195,8 +195,8 @@ where
         let mut state_id = ROOT_STATE_IDX;
         for (pos, c) in self.haystack.by_ref() {
             // self.state_id is always smaller than self.pma.states.len() because
-            // self.pma.get_next_state_id_unchecked() ensures to return such a value.
-            state_id = unsafe { self.pma.get_next_state_id_unchecked(state_id, c) };
+            // self.pma.next_state_id_unchecked() ensures to return such a value.
+            state_id = unsafe { self.pma.next_state_id_unchecked(state_id, c) };
             if let Some(output_pos) = unsafe {
                 self.pma
                     .states
@@ -232,8 +232,8 @@ where
     fn next(&mut self) -> Option<Self::Item> {
         for (pos, c) in self.haystack.by_ref() {
             // self.state_id is always smaller than self.pma.states.len() because
-            // self.pma.get_next_state_id_unchecked() ensures to return such a value.
-            self.state_id = unsafe { self.pma.get_next_state_id_unchecked(self.state_id, c) };
+            // self.pma.next_state_id_unchecked() ensures to return such a value.
+            self.state_id = unsafe { self.pma.next_state_id_unchecked(self.state_id, c) };
             if let Some(output_pos) = unsafe {
                 self.pma
                     .states
@@ -275,8 +275,8 @@ where
             skips += c.len_utf8();
 
             // state_id is always smaller than self.pma.states.len() because
-            // self.pma.get_next_state_id_leftmost_unchecked() ensures to return such a value.
-            state_id = unsafe { self.pma.get_next_state_id_leftmost_unchecked(state_id, c) };
+            // self.pma.next_state_id_leftmost_unchecked() ensures to return such a value.
+            state_id = unsafe { self.pma.next_state_id_leftmost_unchecked(state_id, c) };
             if state_id == ROOT_STATE_IDX {
                 if let Some(output_pos) = last_output_pos {
                     // last_output_pos is always smaller than self.pma.outputs.len() because
@@ -293,7 +293,7 @@ where
                     });
                 }
             // state_id is always smaller than self.pma.states.len() because
-            // self.pma.get_next_state_id_leftmost_unchecked() ensures to return such a value.
+            // self.pma.next_state_id_leftmost_unchecked() ensures to return such a value.
             } else if let Some(output_pos) = unsafe {
                 self.pma
                     .states

--- a/src/nfa_builder.rs
+++ b/src/nfa_builder.rs
@@ -96,7 +96,7 @@ where
                 }
             }
 
-            if let Some(next_state_id) = self.get_child_id(state_id, c) {
+            if let Some(next_state_id) = self.child_id(state_id, c) {
                 state_id = next_state_id;
             } else if let Ok(next_state_id) = u32::try_from(self.states.len()) {
                 self.states[usize::from_u32(state_id)]
@@ -139,7 +139,7 @@ where
             for (&c, &child_id) in &s.edges {
                 let mut fail_id = s.fail;
                 let new_fail_id = loop {
-                    if let Some(child_fail_id) = self.get_child_id(fail_id, c) {
+                    if let Some(child_fail_id) = self.child_id(fail_id, c) {
                         break child_fail_id;
                     }
                     let next_fail_id = self.states[usize::from_u32(fail_id)].borrow().fail;
@@ -185,7 +185,7 @@ where
                     DEAD_STATE_ID
                 } else {
                     loop {
-                        if let Some(child_fail_id) = self.get_child_id(fail_id, c) {
+                        if let Some(child_fail_id) = self.child_id(fail_id, c) {
                             break child_fail_id;
                         }
                         let next_fail_id = self.states[usize::from_u32(fail_id)].borrow().fail;
@@ -226,7 +226,7 @@ where
     }
 
     #[inline(always)]
-    fn get_child_id(&self, state_id: u32, c: L) -> Option<u32> {
+    fn child_id(&self, state_id: u32, c: L) -> Option<u32> {
         self.states[usize::from_u32(state_id)]
             .borrow()
             .edges


### PR DESCRIPTION
This branch renames some functions as follows:

* Removes the prefix `get_`.
* Removes the prefix `set_` from zero-cost functions, adds the suffix `_mut`, and changes to return the mutable reference.

For some structures, leave `set_` for consistency.