### PR TITLE
Introduce a more flexible overlapping iterator API

### DIFF
--- a/src/bytewise.rs
+++ b/src/bytewise.rs
@@ -16,8 +16,7 @@ use crate::utils::FromU32;
 use crate::{MatchKind, Output};
 pub use builder::DoubleArrayAhoCorasickBuilder;
 use iter::{
-    FindIterator, FindOverlappingIterator, FindOverlappingNoSuffixIterator, LestmostFindIterator,
-    U8SliceIterator,
+    FindIterator, FindOverlappingIterator, FindOverlappingNoSuffixIterator, LestmostFindIterator, OverlappingStepper, U8SliceIterator
 };
 
 // The root index position.
@@ -281,6 +280,16 @@ impl<V> DoubleArrayAhoCorasick<V> {
         FindOverlappingIterator {
             pma: self,
             haystack: U8SliceIterator::new(haystack).enumerate(),
+            state_id: ROOT_STATE_IDX,
+            output_pos: None,
+            pos: 0,
+        }
+    }
+
+    ///
+    pub fn overlapping_stepper(&self) -> OverlappingStepper<V> {
+        OverlappingStepper {
+            pma: self,
             state_id: ROOT_STATE_IDX,
             output_pos: None,
             pos: 0,

--- a/src/bytewise/iter.rs
+++ b/src/bytewise/iter.rs
@@ -95,6 +95,7 @@ pub struct OverlappingStepper<'a, V> {
 
 impl<'a, V: Copy> OverlappingStepper<'a, V> {
     ///
+    #[inline(always)]
     pub fn consume(&mut self, c: u8) {
         // self.state_id is always smaller than self.pma.states.len() because
         // self.pma.next_state_id_unchecked() ensures to return such a value.
@@ -109,6 +110,7 @@ impl<'a, V: Copy> OverlappingStepper<'a, V> {
     }
 
     ///
+    #[inline(always)]
     pub fn next(&mut self) -> Option<Match<V>> {
         let output_pos = self.output_pos?;
         // output_pos.get() is always smaller than self.pma.outputs.len() because

--- a/src/bytewise/iter.rs
+++ b/src/bytewise/iter.rs
@@ -84,6 +84,49 @@ where
     }
 }
 
+/// In contrast to the iterator APIs, this one requires the caller to feed in bytes
+/// and take out matches.
+pub struct OverlappingStepper<'a, V> {
+    pub(crate) pma: &'a DoubleArrayAhoCorasick<V>,
+    pub(crate) state_id: u32,
+    pub(crate) pos: usize,
+    pub(crate) output_pos: Option<NonZeroU32>,
+}
+
+impl<'a, V: Copy> OverlappingStepper<'a, V> {
+    ///
+    pub fn consume(&mut self, c: u8) {
+        // self.state_id is always smaller than self.pma.states.len() because
+        // self.pma.next_state_id_unchecked() ensures to return such a value.
+        self.state_id = unsafe { self.pma.next_state_id_unchecked(self.state_id, c) };
+        self.output_pos = unsafe {
+            self.pma
+                .states
+                .get_unchecked(usize::from_u32(self.state_id))
+                .output_pos()
+        };
+        self.pos += 1;
+    }
+
+    ///
+    pub fn next(&mut self) -> Option<Match<V>> {
+        let output_pos = self.output_pos?;
+        // output_pos.get() is always smaller than self.pma.outputs.len() because
+        // Output::parent() ensures to return such a value when it is Some.
+        let out = unsafe {
+            self.pma
+                .outputs
+                .get_unchecked(usize::from_u32(output_pos.get() - 1))
+        };
+        self.output_pos = out.parent();
+        Some(Match {
+            length: usize::from_u32(out.length()),
+            end: self.pos,
+            value: out.value(),
+        })
+    }
+}
+
 /// Iterator created by [`DoubleArrayAhoCorasick::find_overlapping_iter()`].
 pub struct FindOverlappingIterator<'a, P, V> {
     pub(crate) pma: &'a DoubleArrayAhoCorasick<V>,


### PR DESCRIPTION
Please let me know if you would be willing to accept such a change.

The existing overlapping iterator implementation could be simplified with this API as well.