### PR TITLE
Parenthesize shift expressions

### DIFF
--- a/src/charwise/iter.rs
+++ b/src/charwise/iter.rs
@@ -79,18 +79,18 @@ where
             let (i, rest) = unsafe { self.inner.next().unwrap_unchecked() };
             let c = u32::from(rest & 0x3f);
             if first < 0xe0 {
-                (i + 1, u32::from(first & 0x1f) << 6 | c)
+                (i + 1, (u32::from(first & 0x1f) << 6) | c)
             } else {
                 // 3 bytes ~
                 let (i, rest) = unsafe { self.inner.next().unwrap_unchecked() };
-                let c = c << 6 | u32::from(rest & 0x3f);
+                let c = (c << 6) | u32::from(rest & 0x3f);
                 if first < 0xf0 {
-                    (i + 1, u32::from(first & 0x0f) << 12 | c)
+                    (i + 1, (u32::from(first & 0x0f) << 12) | c)
                 } else {
                     // 4 bytes
                     let (i, rest) = unsafe { self.inner.next().unwrap_unchecked() };
-                    let c = c << 6 | u32::from(rest & 0x3f);
-                    (i + 1, u32::from(first & 0x07) << 18 | c)
+                    let c = (c << 6) | u32::from(rest & 0x3f);
+                    (i + 1, (u32::from(first & 0x07) << 18) | c)
                 }
             }
         };

--- a/src/intpack.rs
+++ b/src/intpack.rs
@@ -43,12 +43,12 @@ impl U24nU8 {
 
     #[inline(always)]
     pub fn set_a(&mut self, a: U24) {
-        self.0 = a.get() << 8 | u32::from(self.b());
+        self.0 = (a.get() << 8) | u32::from(self.b());
     }
 
     #[inline(always)]
     pub fn set_b(&mut self, b: u8) {
-        self.0 = self.a().get() << 8 | u32::from(b);
+        self.0 = (self.a().get() << 8) | u32::from(b);
     }
 }
 


### PR DESCRIPTION
Fixes clippy errors on nightly: https://github.com/daac-tools/daachorse/actions/runs/12531326212/job/34948819233