### PR TITLE
Update settings for GitHub Actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,10 +10,10 @@ on:
     tags:
       - 'v*.*.*'
 
-name: build
+permissions:
+  contents: read
 
-env:
-  CARGO_UNSTABLE_SPARSE_REGISTRY: true
+name: build
 
 jobs:
   build:
@@ -26,7 +26,7 @@ jobs:
           - stable
           - nightly
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Install ${{ matrix.rust }}
         run: |
           rustup toolchain install ${{ matrix.rust }} --profile minimal --component rustfmt,clippy
@@ -74,7 +74,7 @@ jobs:
     if: "startsWith(github.ref, 'refs/tags/')"
     needs: [ build ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Install latest stable
         run: |
           rustup toolchain install stable --profile minimal


### PR DESCRIPTION
* Updates [actions/checkout](https://github.com/actions/checkout) to v6.
* Sets GitHub Actions permissions to read-only for this repository. This is effective in preventing repository takeover via supply chain attacks.
* Removes obsolete `CARGO_UNSTABLE_SPARSE_REGISTRY`. Sparse registry is enabled by default as of [Rust 1.70](https://blog.rust-lang.org/2023/06/01/Rust-1.70.0/). 