### PR TITLE
Setup trusted publishing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,14 +73,13 @@ jobs:
     runs-on: ubuntu-latest
     if: "startsWith(github.ref, 'refs/tags/')"
     needs: [ build ]
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v6
-      - name: Install latest stable
-        run: |
-          rustup toolchain install stable --profile minimal
-          rustup default stable
-
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
       - name: Run cargo publish
         run: cargo publish
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -74,6 +74,7 @@ jobs:
     if: "startsWith(github.ref, 'refs/tags/')"
     needs: [ build ]
     permissions:
+      contents: read
       id-token: write
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
This branch changes to use [Trusted Publishing](https://crates.io/docs/trusted-publishing) instead of reusing an ID token.
The ID token have already been removed from the secrets.