### PR TITLE
Ensure automaton contains at least one state

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "daachorse"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2021"
 rust-version = "1.77"
 authors = [

--- a/src/bytewise.rs
+++ b/src/bytewise.rs
@@ -1226,4 +1226,16 @@ mod tests {
         assert_eq!(pma.match_kind, other.match_kind);
         assert_eq!(pma.num_states, other.num_states);
     }
+
+    #[test]
+    fn test_deserialize_invalid_pma() {
+        let bytes = [
+            0, 0, 0, 0, // states
+            0, 0, 0, 0, // outputs
+            0, // match_kind
+            0, 0, 0, 0, // num_states
+        ];
+        let pma = DoubleArrayAhoCorasick::<u32>::deserialize(&bytes);
+        assert!(pma.is_err());
+    }
 }

--- a/src/bytewise.rs
+++ b/src/bytewise.rs
@@ -764,6 +764,9 @@ impl<V> DoubleArrayAhoCorasick<V> {
             num_states,
         };
         let block_len = 256;
+        if pma.states.is_empty() {
+            return Err(DaachorseError::invalid_automaton());
+        }
         if pma.states.len() % block_len != 0 {
             return Err(DaachorseError::invalid_automaton());
         }

--- a/src/charwise.rs
+++ b/src/charwise.rs
@@ -1292,4 +1292,18 @@ mod tests {
         assert_eq!(pma.match_kind, other.match_kind);
         assert_eq!(pma.num_states, other.num_states);
     }
+
+    #[test]
+    fn test_deserialize_invalid_pma() {
+        let bytes = [
+            0, 0, 0, 0, // states
+            0, 0, 0, 0, // table
+            0, 0, 0, 0, // alphabet_size
+            0, 0, 0, 0, // outputs
+            0, // match_kind
+            0, 0, 0, 0, // num_states
+        ];
+        let pma = CharwiseDoubleArrayAhoCorasick::<u32>::deserialize(&bytes);
+        assert!(pma.is_err());
+    }
 }

--- a/src/charwise.rs
+++ b/src/charwise.rs
@@ -816,6 +816,9 @@ impl<V> CharwiseDoubleArrayAhoCorasick<V> {
             }
         }
         let block_len = usize::from_u32(pma.mapper.alphabet_size().next_power_of_two().max(2));
+        if pma.states.is_empty() {
+            return Err(DaachorseError::invalid_automaton());
+        }
         if pma.states.len() % block_len != 0 {
             return Err(DaachorseError::invalid_automaton());
         }

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -108,6 +108,9 @@ where
     #[inline(always)]
     fn deserialize_from_slice(src: &[u8]) -> Result<(Self, &[u8])> {
         let (len, mut src) = u32::deserialize_from_slice(src)?;
+        if usize::from_u32(len) > src.len() {
+            return Err(DaachorseError::invalid_automaton());
+        }
         let mut dst = Self::with_capacity(usize::from_u32(len));
         for _ in 0..len {
             let (x, rest) = S::deserialize_from_slice(src)?;

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -108,7 +108,9 @@ where
     #[inline(always)]
     fn deserialize_from_slice(src: &[u8]) -> Result<(Self, &[u8])> {
         let (len, mut src) = u32::deserialize_from_slice(src)?;
-        if usize::from_u32(len) > src.len() {
+        // To mitigate out-of-memory crashes when parsing a maliciously crafted automaton, restrict
+        // the memory allocation to not exceed the byte limit provided as an argument.
+        if usize::from_u32(len) * core::mem::size_of::<S>() > src.len() {
             return Err(DaachorseError::invalid_automaton());
         }
         let mut dst = Self::with_capacity(usize::from_u32(len));


### PR DESCRIPTION
While `states` must have at least one element to represent the initial state of the automaton, the current implementation does not verify that the length of states is non-zero during deserialization.
This can lead to undefined behavior when handling an invalid automaton.

This pull request fixes this issue.