### PR TITLE
perf: Improve EdgeMap

### DIFF
--- a/src/bytewise/builder.rs
+++ b/src/bytewise/builder.rs
@@ -271,7 +271,7 @@ impl DoubleArrayAhoCorasickBuilder {
                 self.extend_array(&mut helper)?;
             }
 
-            for (&c, &child_id) in &s.edges {
+            for &(c, child_id) in s.edges.iter() {
                 let child_idx = base.get() ^ u32::from(c);
                 helper.use_index(child_idx);
                 self.states[usize::from_u32(child_idx)].set_check(c);

--- a/src/charwise/builder.rs
+++ b/src/charwise/builder.rs
@@ -260,7 +260,7 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
             }
 
             mapped.clear();
-            for (&label, &child_id) in &s.edges {
+            for &(label, child_id) in s.edges.iter() {
                 mapped.push((self.mapper.get(label).unwrap(), child_id));
             }
             mapped.sort_unstable_by_key(|x| x.0);

--- a/src/edge_map.rs
+++ b/src/edge_map.rs
@@ -1,7 +1,7 @@
 use alloc::vec::Vec;
 
 #[derive(Clone, Default)]
-pub(crate) enum EdgeMap<L> {
+pub enum EdgeMap<L> {
     #[default]
     Empty,
     One((L, u32)),
@@ -12,7 +12,7 @@ impl<L> EdgeMap<L>
 where
     L: Ord + Copy,
 {
-    pub(crate) fn insert(&mut self, key: L, value: u32) {
+    pub fn insert(&mut self, key: L, value: u32) {
         match self {
             Self::Empty => {
                 *self = Self::One((key, value));
@@ -43,7 +43,7 @@ where
         }
     }
 
-    pub(crate) fn get(&self, key: &L) -> Option<&u32> {
+    pub fn get(&self, key: &L) -> Option<&u32> {
         match self {
             Self::Empty => None,
             Self::One((k, v)) => (*key == *k).then_some(v),
@@ -54,19 +54,19 @@ where
         }
     }
 
-    pub(crate) fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         matches!(self, Self::Empty)
     }
 
-    pub(crate) fn keys(&self) -> impl Iterator<Item = &L> {
+    pub fn keys(&self) -> impl Iterator<Item = &L> {
         self.iter().map(|(k, _)| k)
     }
 
-    pub(crate) fn values(&self) -> impl Iterator<Item = &u32> {
+    pub fn values(&self) -> impl Iterator<Item = &u32> {
         self.iter().map(|(_, v)| v)
     }
 
-    pub(crate) fn iter(&self) -> impl Iterator<Item = &(L, u32)> {
+    pub fn iter(&self) -> impl Iterator<Item = &(L, u32)> {
         match self {
             Self::Empty => [].iter(),
             Self::One(entry) => core::slice::from_ref(entry).iter(),

--- a/src/edge_map.rs
+++ b/src/edge_map.rs
@@ -1,0 +1,76 @@
+use alloc::vec::Vec;
+
+#[derive(Clone, Default)]
+pub(crate) enum EdgeMap<L> {
+    #[default]
+    Empty,
+    One((L, u32)),
+    Many(Vec<(L, u32)>),
+}
+
+impl<L> EdgeMap<L>
+where
+    L: Ord + Copy,
+{
+    pub(crate) fn insert(&mut self, key: L, value: u32) {
+        match self {
+            Self::Empty => {
+                *self = Self::One((key, value));
+            }
+            Self::One((k, v)) => {
+                if key == *k {
+                    *v = value;
+                    return;
+                }
+                let mut entries = Vec::with_capacity(2);
+                if key < *k {
+                    entries.push((key, value));
+                    entries.push((*k, *v));
+                } else {
+                    entries.push((*k, *v));
+                    entries.push((key, value));
+                }
+                *self = Self::Many(entries);
+            }
+            Self::Many(entries) => match entries.binary_search_by_key(&key, |(k, _)| *k) {
+                Ok(pos) => {
+                    entries[pos].1 = value;
+                }
+                Err(pos) => {
+                    entries.insert(pos, (key, value));
+                }
+            },
+        }
+    }
+
+    pub(crate) fn get(&self, key: &L) -> Option<&u32> {
+        match self {
+            Self::Empty => None,
+            Self::One((k, v)) => (*key == *k).then_some(v),
+            Self::Many(entries) => entries
+                .binary_search_by_key(key, |(k, _)| *k)
+                .ok()
+                .map(|pos| &entries[pos].1),
+        }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        matches!(self, Self::Empty)
+    }
+
+    pub(crate) fn keys(&self) -> impl Iterator<Item = &L> {
+        self.iter().map(|(k, _)| k)
+    }
+
+    pub(crate) fn values(&self) -> impl Iterator<Item = &u32> {
+        self.iter().map(|(_, v)| v)
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &(L, u32)> {
+        match self {
+            Self::Empty => [].iter(),
+            Self::One(entry) => core::slice::from_ref(entry).iter(),
+            Self::Many(entries) => entries.iter(),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,6 +192,7 @@ extern crate alloc;
 mod build_helper;
 pub mod bytewise;
 pub mod charwise;
+mod edge_map;
 pub mod errors;
 mod intpack;
 mod nfa_builder;

--- a/src/nfa_builder.rs
+++ b/src/nfa_builder.rs
@@ -3,6 +3,7 @@ use core::num::NonZeroU32;
 
 use alloc::vec::Vec;
 
+use crate::edge_map::EdgeMap;
 use crate::errors::{DaachorseError, Result};
 use crate::utils::FromU32;
 use crate::{MatchKind, Output};
@@ -27,9 +28,6 @@ impl EdgeLabel for char {
         self.len_utf8()
     }
 }
-
-/// Mapping edge labels to child ids using `BTreeMap`.
-type EdgeMap<L> = alloc::collections::BTreeMap<L, u32>;
 
 /// State of [`NfaBuilder`].
 #[derive(Clone)]
@@ -126,7 +124,7 @@ where
             qi += 1;
 
             let s = &self.states[state_id];
-            for (&c, &child_id) in &s.edges {
+            for &(c, child_id) in s.edges.iter() {
                 let mut fail_id = s.fail.get();
                 let new_fail_id = loop {
                     if let Some(child_fail_id) = self.child_id(fail_id, c) {
@@ -173,7 +171,7 @@ where
                 s.fail.set(DEAD_STATE_ID);
             }
 
-            for (&c, &child_id) in &s.edges {
+            for &(c, child_id) in s.edges.iter() {
                 let mut fail_id = s.fail.get();
 
                 // If the parent has the dead fail, the child also has the dead fail.


### PR DESCRIPTION
This branch uses a custom array-based map instead of a BTreeMap for edge-to-value mapping in the automaton builder.

It is known that a BTreeMap is faster than a HashMap when the number of keys is small. However, for many of the pattern sets handled by daachorse, most nodes only have a few edges, making even the overhead of the BTreeMap's tree structure a bottleneck.

With this change, a reduction in construction time of up to 42% was confirmed, demonstrating significant improvements across all benchmarks.

```
words_100/build/daachorse/bytewise/u64
                        time:   [48.667 µs 49.023 µs 49.516 µs]
                        change: [-30.625% -30.046% -29.397%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild

words_100/build/daachorse/charwise/u64
                        time:   [39.216 µs 39.352 µs 39.486 µs]
                        change: [-43.507% -42.868% -42.206%] (p = 0.00 < 0.05)
                        Performance has improved.

words_5000/build/daachorse/bytewise/u64
                        time:   [4.0208 ms 4.0810 ms 4.1568 ms]
                        change: [-26.185% -25.039% -23.569%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high severe

words_5000/build/daachorse/charwise/u64
                        time:   [2.7939 ms 2.8311 ms 2.8737 ms]
                        change: [-28.077% -26.879% -25.657%] (p = 0.00 < 0.05)
                        Performance has improved.

words_15000/build/daachorse/bytewise/u64
                        time:   [9.2337 ms 9.4211 ms 9.6389 ms]
                        change: [-19.806% -17.881% -15.845%] (p = 0.00 < 0.05)
                        Performance has improved.

words_15000/build/daachorse/charwise/u64
                        time:   [7.4604 ms 7.4795 ms 7.5063 ms]
                        change: [-31.173% -29.946% -28.870%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) low severe
  1 (10.00%) high severe

Benchmarking words_100000/build/daachorse/bytewise/u64: Warming up for 500.00 ms
Warning: Unable to complete 10 samples in 2.0s. You may wish to increase target time to 2.0s.
words_100000/build/daachorse/bytewise/u64
                        time:   [163.50 ms 166.28 ms 169.50 ms]
                        change: [-21.477% -20.035% -18.259%] (p = 0.00 < 0.05)
                        Performance has improved.

words_100000/build/daachorse/charwise/u64
                        time:   [101.40 ms 101.97 ms 102.88 ms]
                        change: [-40.191% -39.500% -38.737%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe

cl100k/build/daachorse/bytewise/u64
                        time:   [39.161 ms 39.381 ms 39.628 ms]
                        change: [-20.511% -19.197% -18.095%] (p = 0.00 < 0.05)
                        Performance has improved.

o200k/build/daachorse/bytewise/u64
                        time:   [87.535 ms 89.048 ms 90.678 ms]
                        change: [-17.899% -15.641% -13.263%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking unidic/build/daachorse/bytewise/u64: Warming up for 500.00 ms
Warning: Unable to complete 10 samples in 2.0s. You may wish to increase target time to 3.9s.
unidic/build/daachorse/bytewise/u64
                        time:   [368.95 ms 374.62 ms 381.30 ms]
                        change: [-22.897% -21.361% -19.842%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking unidic/build/daachorse/charwise/u64: Warming up for 500.00 ms
Warning: Unable to complete 10 samples in 2.0s. You may wish to increase target time to 19.3s.
unidic/build/daachorse/charwise/u64
                        time:   [1.8350 s 1.8557 s 1.8784 s]
                        change: [-5.7747% -4.1446% -2.4804%] (p = 0.00 < 0.05)
                        Performance has improved.
```