### PR TITLE
Add root table for efficient transition

### DIFF
--- a/src/bytewise.rs
+++ b/src/bytewise.rs
@@ -6,6 +6,7 @@ pub mod iter;
 use core::mem;
 use core::num::NonZeroU32;
 
+use alloc::boxed::Box;
 use alloc::vec::Vec;
 
 use crate::build_helper::BuildHelper;
@@ -55,6 +56,7 @@ pub struct DoubleArrayAhoCorasick<V> {
     outputs: Vec<Output<V>>,
     match_kind: MatchKind,
     num_states: u32,
+    root_table: Box<[u32; 256]>,
 }
 
 impl<V> DoubleArrayAhoCorasick<V> {
@@ -748,12 +750,13 @@ impl<V> DoubleArrayAhoCorasick<V> {
     /// let patterns = vec!["bcd", "ab", "a"];
     /// let pma = DoubleArrayAhoCorasick::<u32>::new(patterns).unwrap();
     ///
-    /// assert_eq!(3108, pma.heap_bytes());
+    /// assert_eq!(4132, pma.heap_bytes());
     /// ```
     #[must_use]
     pub fn heap_bytes(&self) -> usize {
         self.states.len() * mem::size_of::<State>()
             + self.outputs.len() * mem::size_of::<Output<V>>()
+            + mem::size_of::<[u32; 256]>()
     }
 
     /// Returns the total number of states this automaton has.
@@ -856,11 +859,13 @@ impl<V> DoubleArrayAhoCorasick<V> {
         let (outputs, source) = Vec::<Output<V>>::deserialize_from_slice(source)?;
         let (match_kind, source) = MatchKind::deserialize_from_slice(source)?;
         let (num_states, source) = u32::deserialize_from_slice(source)?;
+        let root_table = Self::build_root_table(&states);
         let pma = Self {
             states,
             outputs,
             match_kind,
             num_states,
+            root_table,
         };
         let block_len = 256;
         if pma.states.is_empty() {
@@ -947,15 +952,36 @@ impl<V> DoubleArrayAhoCorasick<V> {
         let (outputs, source) = Vec::<Output<V>>::deserialize_from_slice(source).unwrap_unchecked();
         let (match_kind, source) = MatchKind::deserialize_from_slice(source).unwrap_unchecked();
         let (num_states, source) = u32::deserialize_from_slice(source).unwrap_unchecked();
+        let root_table = Self::build_root_table(&states);
         (
             Self {
                 states,
                 outputs,
                 match_kind,
                 num_states,
+                root_table,
             },
             source,
         )
+    }
+
+    /// Builds a dense transition table for the root state.
+    fn build_root_table(states: &[State]) -> Box<[u32; 256]> {
+        let mut table = Box::new([ROOT_STATE_IDX; 256]);
+        if let Some(base) = states
+            .get(usize::from_u32(ROOT_STATE_IDX))
+            .and_then(State::base)
+        {
+            for c in 0..=255u8 {
+                let child_idx = base.get() ^ u32::from(c);
+                if let Some(child) = states.get(usize::from_u32(child_idx)) {
+                    if child.check() == c {
+                        table[usize::from(c)] = child_idx;
+                    }
+                }
+            }
+        }
+        table
     }
 
     /// # Safety
@@ -964,6 +990,12 @@ impl<V> DoubleArrayAhoCorasick<V> {
     #[inline(always)]
     unsafe fn next_state_id_unchecked(&self, mut state_id: u32, c: u8) -> u32 {
         loop {
+            // The root state is by far the most frequent one, so its transitions are precomputed in
+            // a dense table.
+            if state_id == ROOT_STATE_IDX {
+                return self.root_table[usize::from(c)];
+            }
+
             // Get the current state.
             let state = self.states.get_unchecked(usize::from_u32(state_id));
 
@@ -976,11 +1008,6 @@ impl<V> DoubleArrayAhoCorasick<V> {
                 if child.check() == c {
                     return child_idx;
                 }
-            }
-
-            // If no transition is found and we are already at the root state, stay/reset at the root state.
-            if state_id == ROOT_STATE_IDX {
-                return ROOT_STATE_IDX;
             }
 
             // Follow the failure transition to the next candidate state.

--- a/src/bytewise/builder.rs
+++ b/src/bytewise/builder.rs
@@ -213,11 +213,13 @@ impl DoubleArrayAhoCorasickBuilder {
         let num_states = u32::try_from(nfa.states.len() - 1)
             .map_err(|_| DaachorseError::automaton_scale("num_states", u32::MAX))?;
 
+        let root_table = DoubleArrayAhoCorasick::<V>::build_root_table(&self.states);
         Ok(DoubleArrayAhoCorasick {
             states: self.states,
             outputs: nfa.outputs,
             match_kind: self.match_kind,
             num_states,
+            root_table,
         })
     }
 


### PR DESCRIPTION
This branch precomputes transitions from the root state and stores it in the root table. While this change caused a slight performance regression in a few benchmarks, it significantly improved speed across most situations.

Since it had no effect on leftmost search and charwise, it has not been implemented for them.
```
words_100/find/daachorse/bytewise/u64
                        time:   [2.6994 ms 2.7263 ms 2.7552 ms]
                        change: [-23.914% -22.983% -22.075%] (p = 0.00 < 0.05)
                        Performance has improved.

words_5000/find/daachorse/bytewise/u64
                        time:   [3.4508 ms 3.4573 ms 3.4649 ms]
                        change: [-4.5915% -3.8465% -3.2092%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 30 measurements (13.33%)
  2 (6.67%) high mild
  2 (6.67%) high severe

words_15000/find/daachorse/bytewise/u64
                        time:   [3.4956 ms 3.5358 ms 3.5861 ms]
                        change: [+0.5273% +1.6493% +3.2169%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 30 measurements (16.67%)
  2 (6.67%) high mild
  3 (10.00%) high severe

words_100000/find/daachorse/bytewise/u64
                        time:   [3.3858 ms 3.4084 ms 3.4348 ms]
                        change: [-2.9782% -2.0784% -1.1521%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 30 measurements (3.33%)
  1 (3.33%) high mild

cl100k/find/daachorse/bytewise/u64
                        time:   [1.0792 ms 1.0906 ms 1.1051 ms]
                        change: [-11.310% -10.424% -9.2636%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 30 measurements (10.00%)
  3 (10.00%) high severe

o200k/find/daachorse/bytewise/u64
                        time:   [1.0833 ms 1.0961 ms 1.1124 ms]
                        change: [-19.731% -17.526% -15.512%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 30 measurements (13.33%)
  1 (3.33%) high mild
  3 (10.00%) high severe

unidic/find/daachorse/bytewise/u64
                        time:   [1.3115 ms 1.3224 ms 1.3371 ms]
                        change: [-0.4012% +1.2534% +2.8990%] (p = 0.14 > 0.05)
                        No change in performance detected.
Found 1 outliers among 30 measurements (3.33%)
  1 (3.33%) high severe

words_100/find_overlapping/daachorse/bytewise/u64
                        time:   [2.8203 ms 2.8296 ms 2.8401 ms]
                        change: [-21.741% -21.170% -20.641%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 30 measurements (3.33%)
  1 (3.33%) high mild

words_5000/find_overlapping/daachorse/bytewise/u64
                        time:   [3.6937 ms 3.7068 ms 3.7197 ms]
                        change: [-2.3639% -1.0053% +0.1949%] (p = 0.15 > 0.05)
                        No change in performance detected.
Found 7 outliers among 30 measurements (23.33%)
  5 (16.67%) low mild
  1 (3.33%) high mild
  1 (3.33%) high severe

words_15000/find_overlapping/daachorse/bytewise/u64
                        time:   [3.7272 ms 3.7726 ms 3.8270 ms]
                        change: [+1.9936% +3.4289% +4.9467%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 3 outliers among 30 measurements (10.00%)
  2 (6.67%) high mild
  1 (3.33%) high severe

words_100000/find_overlapping/daachorse/bytewise/u64
                        time:   [3.9205 ms 3.9535 ms 3.9937 ms]
                        change: [-1.1449% +0.2546% +1.6329%] (p = 0.73 > 0.05)
                        No change in performance detected.
Found 3 outliers among 30 measurements (10.00%)
  1 (3.33%) high mild
  2 (6.67%) high severe

cl100k/find_overlapping/daachorse/bytewise/u64
                        time:   [5.7872 ms 5.8154 ms 5.8447 ms]
                        change: [-12.932% -12.444% -11.915%] (p = 0.00 < 0.05)
                        Performance has improved.

o200k/find_overlapping/daachorse/bytewise/u64
                        time:   [6.1568 ms 6.2050 ms 6.2726 ms]
                        change: [-7.7855% -6.9817% -5.9330%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 30 measurements (30.00%)
  4 (13.33%) low severe
  1 (3.33%) low mild
  4 (13.33%) high severe

unidic/find_overlapping/daachorse/bytewise/u64
                        time:   [11.322 ms 11.465 ms 11.639 ms]
                        change: [-4.5662% -2.3513% -0.1741%] (p = 0.04 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 30 measurements (13.33%)
  1 (3.33%) high mild
  3 (10.00%) high severe
```