### PR TITLE
perf: Separate fail edges in leftmost search

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "daachorse"
 
 # This library adheres to Semantic Versioning.
 # See: https://semver.org/
-version = "3.0.3"
+version = "4.0.0"
 
 # Bumping the MSRV breaks backward compatibility. If you bump it, please increment the major version
 # of the library as well.

--- a/src/bytewise.rs
+++ b/src/bytewise.rs
@@ -7,7 +7,6 @@ use core::fmt::Debug;
 use core::mem;
 use core::num::NonZeroU32;
 
-use alloc::boxed::Box;
 use alloc::vec::Vec;
 
 use crate::build_helper::BuildHelper;
@@ -55,7 +54,9 @@ const DEAD_STATE_IDX: u32 = 1;
 pub struct DoubleArrayAhoCorasick<V> {
     // for standard matching
     states: Vec<State<u32>>,
-    root_table: Box<[u32; 256]>,
+    // A dense transition table for the root state, which has 256 elements for standard matching
+    // and is empty for leftmost matching.
+    root_table: Vec<u32>,
 
     // for leftmost matching
     leftmost_states: Vec<State<Empty>>,
@@ -762,10 +763,10 @@ impl<V> DoubleArrayAhoCorasick<V> {
     #[must_use]
     pub fn heap_bytes(&self) -> usize {
         self.states.len() * mem::size_of::<State<u32>>()
+            + self.root_table.len() * mem::size_of::<u32>()
             + self.leftmost_states.len() * mem::size_of::<State<Empty>>()
             + self.fails.len() * mem::size_of::<u32>()
             + self.outputs.len() * mem::size_of::<Output<V>>()
-            + mem::size_of::<[u32; 256]>()
     }
 
     /// Returns the total number of states this automaton has.
@@ -874,7 +875,11 @@ impl<V> DoubleArrayAhoCorasick<V> {
         let (outputs, source) = Vec::<Output<V>>::deserialize_from_slice(source)?;
         let (match_kind, source) = MatchKind::deserialize_from_slice(source)?;
         let (num_states, source) = u32::deserialize_from_slice(source)?;
-        let root_table = Self::build_root_table(&states);
+        let root_table = if match_kind.is_leftmost() {
+            vec![]
+        } else {
+            Self::build_root_table(&states)
+        };
         let pma = Self {
             states,
             leftmost_states,
@@ -887,6 +892,9 @@ impl<V> DoubleArrayAhoCorasick<V> {
         let block_len = 256;
         let outputs_len = pma.outputs.len();
         if pma.match_kind.is_leftmost() {
+            if !pma.states.is_empty() {
+                return Err(DaachorseError::invalid_automaton());
+            }
             if pma.leftmost_states.is_empty() {
                 return Err(DaachorseError::invalid_automaton());
             }
@@ -915,10 +923,17 @@ impl<V> DoubleArrayAhoCorasick<V> {
                 }
             }
         } else {
+            if !pma.leftmost_states.is_empty() || !pma.fails.is_empty() {
+                return Err(DaachorseError::invalid_automaton());
+            }
             if pma.states.is_empty() {
                 return Err(DaachorseError::invalid_automaton());
             }
             if pma.states.len() % block_len != 0 {
+                return Err(DaachorseError::invalid_automaton());
+            }
+            // `next_state_id_unchecked()` relies on this invariant.
+            if pma.root_table.len() != block_len {
                 return Err(DaachorseError::invalid_automaton());
             }
             let states_len = pma.states.len();
@@ -1002,7 +1017,11 @@ impl<V> DoubleArrayAhoCorasick<V> {
         let (outputs, source) = Vec::<Output<V>>::deserialize_from_slice(source).unwrap_unchecked();
         let (match_kind, source) = MatchKind::deserialize_from_slice(source).unwrap_unchecked();
         let (num_states, source) = u32::deserialize_from_slice(source).unwrap_unchecked();
-        let root_table = Self::build_root_table(&states);
+        let root_table = if match_kind.is_leftmost() {
+            vec![]
+        } else {
+            Self::build_root_table(&states)
+        };
         (
             Self {
                 states,
@@ -1018,8 +1037,8 @@ impl<V> DoubleArrayAhoCorasick<V> {
     }
 
     /// Builds a dense transition table for the root state.
-    fn build_root_table(states: &[State<u32>]) -> Box<[u32; 256]> {
-        let mut table = Box::new([ROOT_STATE_IDX; 256]);
+    fn build_root_table(states: &[State<u32>]) -> Vec<u32> {
+        let mut table = vec![ROOT_STATE_IDX; 256];
         if let Some(base) = states
             .get(usize::from_u32(ROOT_STATE_IDX))
             .and_then(State::base)
@@ -1038,14 +1057,15 @@ impl<V> DoubleArrayAhoCorasick<V> {
 
     /// # Safety
     ///
-    /// `state_id` must be smaller than the length of states.
+    /// `state_id` must be smaller than the length of states, and `root_table` must have 256
+    /// elements. These are guaranteed for standard matching automata.
     #[inline(always)]
     unsafe fn next_state_id_unchecked(&self, mut state_id: u32, c: u8) -> u32 {
         loop {
             // The root state is by far the most frequent one, so its transitions are precomputed in
             // a dense table.
             if state_id == ROOT_STATE_IDX {
-                return self.root_table[usize::from(c)];
+                return *self.root_table.get_unchecked(usize::from(c));
             }
 
             // Get the current state.

--- a/src/bytewise.rs
+++ b/src/bytewise.rs
@@ -1496,6 +1496,8 @@ mod tests {
     fn test_deserialize_invalid_pma() {
         let bytes = [
             0, 0, 0, 0, // states
+            0, 0, 0, 0, // leftmost_states
+            0, 0, 0, 0, // fails
             0, 0, 0, 0, // outputs
             0, // match_kind
             0, 0, 0, 0, // num_states

--- a/src/bytewise.rs
+++ b/src/bytewise.rs
@@ -761,11 +761,12 @@ impl<V> DoubleArrayAhoCorasick<V> {
     /// ```
     #[must_use]
     pub fn heap_bytes(&self) -> usize {
-self.states.len() * mem::size_of::<State<u32>>()
-    + self.leftmost_states.len() * mem::size_of::<State<Empty>>()
-    + self.fails.len() * mem::size_of::<u32>()
-    + self.outputs.len() * mem::size_of::<Output<V>>()
-    + mem::size_of::<[u32; 256]>()
+        self.states.len() * mem::size_of::<State<u32>>()
+            + self.leftmost_states.len() * mem::size_of::<State<Empty>>()
+            + self.fails.len() * mem::size_of::<u32>()
+            + self.outputs.len() * mem::size_of::<Output<V>>()
+            + mem::size_of::<[u32; 256]>()
+    }
 
     /// Returns the total number of states this automaton has.
     ///
@@ -890,6 +891,9 @@ self.states.len() * mem::size_of::<State<u32>>()
                 return Err(DaachorseError::invalid_automaton());
             }
             if pma.leftmost_states.len() % block_len != 0 {
+                return Err(DaachorseError::invalid_automaton());
+            }
+            if pma.fails.len() != pma.leftmost_states.len() {
                 return Err(DaachorseError::invalid_automaton());
             }
             let states_len = pma.leftmost_states.len();
@@ -1447,12 +1451,12 @@ mod tests {
         let bytes = pma.serialize();
         let (other, rest) = DoubleArrayAhoCorasick::deserialize(&bytes).unwrap();
         assert!(rest.is_empty());
-assert_eq!(pma.states, other.states);
-assert_eq!(pma.leftmost_states, other.leftmost_states);
-assert_eq!(pma.fails, other.fails);
-assert_eq!(pma.outputs, other.outputs);
-assert_eq!(pma.match_kind, other.match_kind);
-assert_eq!(pma.num_states, other.num_states);
+        assert_eq!(pma.states, other.states);
+        assert_eq!(pma.leftmost_states, other.leftmost_states);
+        assert_eq!(pma.fails, other.fails);
+        assert_eq!(pma.outputs, other.outputs);
+        assert_eq!(pma.match_kind, other.match_kind);
+        assert_eq!(pma.num_states, other.num_states);
     }
 
     #[test]

--- a/src/bytewise.rs
+++ b/src/bytewise.rs
@@ -3,6 +3,7 @@
 mod builder;
 pub mod iter;
 
+use core::fmt::Debug;
 use core::mem;
 use core::num::NonZeroU32;
 
@@ -19,7 +20,7 @@ use crate::errors::{DaachorseError, Result};
 use crate::intpack::{U24nU8, U24};
 use crate::serializer::{Serializable, SerializableVec};
 use crate::utils::FromU32;
-use crate::{MatchKind, Output};
+use crate::{Empty, MatchKind, Output};
 
 // The root index position.
 const ROOT_STATE_IDX: u32 = 0;
@@ -52,11 +53,17 @@ const DEAD_STATE_IDX: u32 = 1;
 /// [`DaachorseError`] will be reported.
 #[derive(Clone, Eq, Hash, PartialEq)]
 pub struct DoubleArrayAhoCorasick<V> {
-    states: Vec<State>,
+    // for standard matching
+    states: Vec<State<u32>>,
+    root_table: Box<[u32; 256]>,
+
+    // for leftmost matching
+    leftmost_states: Vec<State<Empty>>,
+    fails: Vec<u32>,
+
     outputs: Vec<Output<V>>,
     match_kind: MatchKind,
     num_states: u32,
-    root_table: Box<[u32; 256]>,
 }
 
 impl<V> DoubleArrayAhoCorasick<V> {
@@ -549,7 +556,7 @@ impl<V> DoubleArrayAhoCorasick<V> {
             haystack,
             pos: 0,
             init_output_pos: unsafe {
-                self.states
+                self.leftmost_states
                     .get_unchecked(usize::from_u32(ROOT_STATE_IDX))
                     .output_pos()
             },
@@ -754,7 +761,9 @@ impl<V> DoubleArrayAhoCorasick<V> {
     /// ```
     #[must_use]
     pub fn heap_bytes(&self) -> usize {
-        self.states.len() * mem::size_of::<State>()
+        self.states.len() * mem::size_of::<State<u32>>()
+            + self.leftmost_states.len() * mem::size_of::<State<u32>>()
+            + self.fails.len() * mem::size_of::<State<u32>>()
             + self.outputs.len() * mem::size_of::<Output<V>>()
             + mem::size_of::<[u32; 256]>()
     }
@@ -794,11 +803,15 @@ impl<V> DoubleArrayAhoCorasick<V> {
     {
         let mut result = Vec::with_capacity(
             self.states.serialized_bytes()
+                + self.leftmost_states.serialized_bytes()
+                + self.fails.serialized_bytes()
                 + self.outputs.serialized_bytes()
                 + MatchKind::serialized_bytes()
                 + u32::serialized_bytes(),
         );
         self.states.serialize_to_vec(&mut result);
+        self.leftmost_states.serialize_to_vec(&mut result);
+        self.fails.serialize_to_vec(&mut result);
         self.outputs.serialize_to_vec(&mut result);
         self.match_kind.serialize_to_vec(&mut result);
         self.num_states.serialize_to_vec(&mut result);
@@ -855,41 +868,72 @@ impl<V> DoubleArrayAhoCorasick<V> {
     where
         V: Serializable,
     {
-        let (states, source) = Vec::<State>::deserialize_from_slice(source)?;
+        let (states, source) = Vec::<State<u32>>::deserialize_from_slice(source)?;
+        let (leftmost_states, source) = Vec::<State<Empty>>::deserialize_from_slice(source)?;
+        let (fails, source) = Vec::<u32>::deserialize_from_slice(source)?;
         let (outputs, source) = Vec::<Output<V>>::deserialize_from_slice(source)?;
         let (match_kind, source) = MatchKind::deserialize_from_slice(source)?;
         let (num_states, source) = u32::deserialize_from_slice(source)?;
         let root_table = Self::build_root_table(&states);
         let pma = Self {
             states,
+            leftmost_states,
+            fails,
             outputs,
             match_kind,
             num_states,
             root_table,
         };
         let block_len = 256;
-        if pma.states.is_empty() {
-            return Err(DaachorseError::invalid_automaton());
-        }
-        if pma.states.len() % block_len != 0 {
-            return Err(DaachorseError::invalid_automaton());
-        }
-        let states_len = pma.states.len();
         let outputs_len = pma.outputs.len();
-        for state in &pma.states {
-            if let Some(base) = state.base() {
-                if usize::from_u32(base.get()) >= states_len {
-                    return Err(DaachorseError::invalid_automaton());
-                }
-            };
-            if usize::from_u32(state.fail()) >= states_len {
+        if pma.match_kind.is_leftmost() {
+            if pma.leftmost_states.is_empty() {
                 return Err(DaachorseError::invalid_automaton());
             }
-            if let Some(output_pos) = state.output_pos() {
-                if usize::from_u32(output_pos.get() - 1) >= outputs_len {
+            if pma.leftmost_states.len() % block_len != 0 {
+                return Err(DaachorseError::invalid_automaton());
+            }
+            let states_len = pma.leftmost_states.len();
+            for state in &pma.leftmost_states {
+                if let Some(base) = state.base() {
+                    if usize::from_u32(base.get()) >= states_len {
+                        return Err(DaachorseError::invalid_automaton());
+                    }
+                };
+                if let Some(output_pos) = state.output_pos() {
+                    if usize::from_u32(output_pos.get() - 1) >= outputs_len {
+                        return Err(DaachorseError::invalid_automaton());
+                    }
+                };
+            }
+            for fail in &pma.fails {
+                if usize::from_u32(*fail) >= states_len {
                     return Err(DaachorseError::invalid_automaton());
                 }
-            };
+            }
+        } else {
+            if pma.states.is_empty() {
+                return Err(DaachorseError::invalid_automaton());
+            }
+            if pma.states.len() % block_len != 0 {
+                return Err(DaachorseError::invalid_automaton());
+            }
+            let states_len = pma.states.len();
+            for state in &pma.states {
+                if let Some(base) = state.base() {
+                    if usize::from_u32(base.get()) >= states_len {
+                        return Err(DaachorseError::invalid_automaton());
+                    }
+                };
+                if usize::from_u32(state.fail()) >= states_len {
+                    return Err(DaachorseError::invalid_automaton());
+                }
+                if let Some(output_pos) = state.output_pos() {
+                    if usize::from_u32(output_pos.get() - 1) >= outputs_len {
+                        return Err(DaachorseError::invalid_automaton());
+                    }
+                };
+            }
         }
         for (i, output) in pma.outputs.iter().enumerate() {
             if let Some(parent) = output.parent {
@@ -948,7 +992,10 @@ impl<V> DoubleArrayAhoCorasick<V> {
     where
         V: Serializable,
     {
-        let (states, source) = Vec::<State>::deserialize_from_slice(source).unwrap_unchecked();
+        let (states, source) = Vec::<State<u32>>::deserialize_from_slice(source).unwrap_unchecked();
+        let (leftmost_states, source) =
+            Vec::<State<Empty>>::deserialize_from_slice(source).unwrap_unchecked();
+        let (fails, source) = Vec::<u32>::deserialize_from_slice(source).unwrap_unchecked();
         let (outputs, source) = Vec::<Output<V>>::deserialize_from_slice(source).unwrap_unchecked();
         let (match_kind, source) = MatchKind::deserialize_from_slice(source).unwrap_unchecked();
         let (num_states, source) = u32::deserialize_from_slice(source).unwrap_unchecked();
@@ -956,6 +1003,8 @@ impl<V> DoubleArrayAhoCorasick<V> {
         (
             Self {
                 states,
+                leftmost_states,
+                fails,
                 outputs,
                 match_kind,
                 num_states,
@@ -966,7 +1015,7 @@ impl<V> DoubleArrayAhoCorasick<V> {
     }
 
     /// Builds a dense transition table for the root state.
-    fn build_root_table(states: &[State]) -> Box<[u32; 256]> {
+    fn build_root_table(states: &[State<u32>]) -> Box<[u32; 256]> {
         let mut table = Box::new([ROOT_STATE_IDX; 256]);
         if let Some(base) = states
             .get(usize::from_u32(ROOT_STATE_IDX))
@@ -1022,13 +1071,17 @@ impl<V> DoubleArrayAhoCorasick<V> {
     unsafe fn next_state_id_leftmost_unchecked(&self, mut state_id: u32, c: u8) -> u32 {
         loop {
             // Get the current state.
-            let state = self.states.get_unchecked(usize::from_u32(state_id));
+            let state = self
+                .leftmost_states
+                .get_unchecked(usize::from_u32(state_id));
 
             // If the state has transitions (indicated by a non-None base value):
             if let Some(base) = state.base() {
                 // Calculate the child index in the double-array using base ^ c.
                 let child_idx = base.get() ^ u32::from(c);
-                let child = self.states.get_unchecked(usize::from_u32(child_idx));
+                let child = self
+                    .leftmost_states
+                    .get_unchecked(usize::from_u32(child_idx));
                 // Verify if the transition exists by checking if the child's check value matches c.
                 if child.check() == c {
                     return child_idx;
@@ -1041,7 +1094,7 @@ impl<V> DoubleArrayAhoCorasick<V> {
             }
 
             // In leftmost matching, we stop searching if the failure path hits the dead state.
-            let fail_id = state.fail();
+            let fail_id = *self.fails.get_unchecked(usize::from_u32(state_id));
             if fail_id == DEAD_STATE_IDX {
                 return ROOT_STATE_IDX;
             }
@@ -1053,14 +1106,17 @@ impl<V> DoubleArrayAhoCorasick<V> {
 }
 
 #[derive(Clone, Copy, Default, Eq, Hash, PartialEq)]
-struct State {
+struct State<F> {
     base: Option<NonZeroU32>,
-    fail: u32,
+    fail: F,
     // 3 bytes for output_pos and 1 byte for check.
     opos_ch: U24nU8,
 }
 
-impl State {
+impl<F> State<F>
+where
+    F: Copy,
+{
     #[inline(always)]
     pub const fn base(&self) -> Option<NonZeroU32> {
         self.base
@@ -1072,7 +1128,7 @@ impl State {
     }
 
     #[inline(always)]
-    pub const fn fail(&self) -> u32 {
+    pub const fn fail(&self) -> F {
         self.fail
     }
 
@@ -1092,7 +1148,7 @@ impl State {
     }
 
     #[inline(always)]
-    pub fn set_fail(&mut self, x: u32) {
+    pub fn set_fail(&mut self, x: F) {
         self.fail = x;
     }
 
@@ -1108,7 +1164,10 @@ impl State {
     }
 }
 
-impl Serializable for State {
+impl<F> Serializable for State<F>
+where
+    F: Serializable,
+{
     #[inline(always)]
     fn serialize_to_vec(&self, dst: &mut Vec<u8>) {
         self.base.serialize_to_vec(dst);
@@ -1119,7 +1178,7 @@ impl Serializable for State {
     #[inline(always)]
     fn deserialize_from_slice(src: &[u8]) -> Result<(Self, &[u8])> {
         let (base, src) = Option::<NonZeroU32>::deserialize_from_slice(src)?;
-        let (fail, src) = u32::deserialize_from_slice(src)?;
+        let (fail, src) = F::deserialize_from_slice(src)?;
         let (opos_ch, src) = U24nU8::deserialize_from_slice(src)?;
         Ok((
             Self {
@@ -1139,7 +1198,10 @@ impl Serializable for State {
     }
 }
 
-impl core::fmt::Debug for State {
+impl<F> core::fmt::Debug for State<F>
+where
+    F: Copy + Debug,
+{
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("State")
             .field("base", &self.base())
@@ -1357,7 +1419,7 @@ mod tests {
         };
         let mut data = vec![];
         x.serialize_to_vec(&mut data);
-        assert_eq!(data.len(), State::serialized_bytes());
+        assert_eq!(data.len(), State::<u32>::serialized_bytes());
         let (y, rest) = State::deserialize_from_slice(&data).unwrap();
         assert!(rest.is_empty());
         assert_eq!(x, y);
@@ -1367,6 +1429,22 @@ mod tests {
     fn test_serialize_pma() {
         let patterns = vec!["abba", "baaba", "ababa"];
         let pma = DoubleArrayAhoCorasick::<u32>::new(patterns).unwrap();
+        let bytes = pma.serialize();
+        let (other, rest) = DoubleArrayAhoCorasick::deserialize(&bytes).unwrap();
+        assert!(rest.is_empty());
+        assert_eq!(pma.states, other.states);
+        assert_eq!(pma.outputs, other.outputs);
+        assert_eq!(pma.match_kind, other.match_kind);
+        assert_eq!(pma.num_states, other.num_states);
+    }
+
+    #[test]
+    fn test_serialize_leftmost_pma() {
+        let patterns = vec!["abba", "baaba", "ababa"];
+        let pma: DoubleArrayAhoCorasick<u32> = DoubleArrayAhoCorasickBuilder::new()
+            .match_kind(MatchKind::LeftmostLongest)
+            .build(patterns)
+            .unwrap();
         let bytes = pma.serialize();
         let (other, rest) = DoubleArrayAhoCorasick::deserialize(&bytes).unwrap();
         assert!(rest.is_empty());

--- a/src/bytewise.rs
+++ b/src/bytewise.rs
@@ -761,12 +761,11 @@ impl<V> DoubleArrayAhoCorasick<V> {
     /// ```
     #[must_use]
     pub fn heap_bytes(&self) -> usize {
-        self.states.len() * mem::size_of::<State<u32>>()
-            + self.leftmost_states.len() * mem::size_of::<State<u32>>()
-            + self.fails.len() * mem::size_of::<State<u32>>()
-            + self.outputs.len() * mem::size_of::<Output<V>>()
-            + mem::size_of::<[u32; 256]>()
-    }
+self.states.len() * mem::size_of::<State<u32>>()
+    + self.leftmost_states.len() * mem::size_of::<State<Empty>>()
+    + self.fails.len() * mem::size_of::<u32>()
+    + self.outputs.len() * mem::size_of::<Output<V>>()
+    + mem::size_of::<[u32; 256]>()
 
     /// Returns the total number of states this automaton has.
     ///
@@ -1448,10 +1447,12 @@ mod tests {
         let bytes = pma.serialize();
         let (other, rest) = DoubleArrayAhoCorasick::deserialize(&bytes).unwrap();
         assert!(rest.is_empty());
-        assert_eq!(pma.states, other.states);
-        assert_eq!(pma.outputs, other.outputs);
-        assert_eq!(pma.match_kind, other.match_kind);
-        assert_eq!(pma.num_states, other.num_states);
+assert_eq!(pma.states, other.states);
+assert_eq!(pma.leftmost_states, other.leftmost_states);
+assert_eq!(pma.fails, other.fails);
+assert_eq!(pma.outputs, other.outputs);
+assert_eq!(pma.match_kind, other.match_kind);
+assert_eq!(pma.num_states, other.num_states);
     }
 
     #[test]

--- a/src/bytewise.rs
+++ b/src/bytewise.rs
@@ -1216,7 +1216,7 @@ where
     #[inline(always)]
     fn serialized_bytes() -> usize {
         Option::<NonZeroU32>::serialized_bytes()
-            + u32::serialized_bytes()
+            + F::serialized_bytes()
             + U24nU8::serialized_bytes()
     }
 }

--- a/src/bytewise/builder.rs
+++ b/src/bytewise/builder.rs
@@ -214,7 +214,7 @@ impl DoubleArrayAhoCorasickBuilder {
         let num_states = u32::try_from(nfa.states.len() - 1)
             .map_err(|_| DaachorseError::automaton_scale("num_states", u32::MAX))?;
 
-        let root_table = DoubleArrayAhoCorasick::<V>::build_root_table(&self.states);
+        let mut root_table = vec![];
         let mut leftmost_states = vec![];
         let mut fails = vec![];
         if self.match_kind.is_leftmost() {
@@ -227,6 +227,8 @@ impl DoubleArrayAhoCorasickBuilder {
                 fails.push(s.fail);
             }
             self.states = vec![];
+        } else {
+            root_table = DoubleArrayAhoCorasick::<V>::build_root_table(&self.states);
         }
         Ok(DoubleArrayAhoCorasick {
             states: self.states,

--- a/src/bytewise/builder.rs
+++ b/src/bytewise/builder.rs
@@ -218,8 +218,9 @@ impl DoubleArrayAhoCorasickBuilder {
         let mut leftmost_states = vec![];
         let mut fails = vec![];
         if self.match_kind.is_leftmost() {
+            leftmost_states.reserve_exact(self.states.len());
+            fails.reserve_exact(self.states.len());
             for s in &self.states {
-                leftmost_states.push(State {
                     base: s.base(),
                     fail: Empty,
                     opos_ch: s.opos_ch,

--- a/src/bytewise/builder.rs
+++ b/src/bytewise/builder.rs
@@ -221,6 +221,7 @@ impl DoubleArrayAhoCorasickBuilder {
             leftmost_states.reserve_exact(self.states.len());
             fails.reserve_exact(self.states.len());
             for s in &self.states {
+                leftmost_states.push(State {
                     base: s.base(),
                     fail: Empty,
                     opos_ch: s.opos_ch,

--- a/src/bytewise/builder.rs
+++ b/src/bytewise/builder.rs
@@ -9,6 +9,7 @@ use crate::errors::{DaachorseError, Result};
 use crate::intpack::U24;
 use crate::nfa_builder::{NfaBuilder, DEAD_STATE_ID, ROOT_STATE_ID};
 use crate::utils::FromU32;
+use crate::Empty;
 
 // The length of each double-array block.
 const BLOCK_LEN: u32 = 256;
@@ -18,7 +19,7 @@ type BytewiseNfaBuilder<V> = NfaBuilder<u8, V>;
 
 /// Builder of [`DoubleArrayAhoCorasick`].
 pub struct DoubleArrayAhoCorasickBuilder {
-    states: Vec<State>,
+    states: Vec<State<u32>>,
     match_kind: MatchKind,
     num_free_blocks: u32,
 }
@@ -214,8 +215,23 @@ impl DoubleArrayAhoCorasickBuilder {
             .map_err(|_| DaachorseError::automaton_scale("num_states", u32::MAX))?;
 
         let root_table = DoubleArrayAhoCorasick::<V>::build_root_table(&self.states);
+        let mut leftmost_states = vec![];
+        let mut fails = vec![];
+        if self.match_kind.is_leftmost() {
+            for s in &self.states {
+                leftmost_states.push(State {
+                    base: s.base(),
+                    fail: Empty,
+                    opos_ch: s.opos_ch,
+                });
+                fails.push(s.fail);
+            }
+            self.states = vec![];
+        }
         Ok(DoubleArrayAhoCorasick {
             states: self.states,
+            leftmost_states,
+            fails,
             outputs: nfa.outputs,
             match_kind: self.match_kind,
             num_states,

--- a/src/bytewise/iter.rs
+++ b/src/bytewise/iter.rs
@@ -276,8 +276,8 @@ where
         let haystack = self.haystack.as_ref();
         'a: loop {
             for (pos, &c) in haystack.iter().enumerate().skip(self.pos) {
-                // state_id is always smaller than self.pma.leftmost_states.len() because
-                // self.pma.next_state_id_leftmost_unchecked() ensures to return such a value.
+                // SAFETY: `state_id` remains < self.pma.leftmost_states.len() for automata built by
+                // the builder or validated by `DoubleArrayAhoCorasick::deserialize()`.
                 state_id = unsafe { self.pma.next_state_id_leftmost_unchecked(state_id, c) };
                 if state_id == ROOT_STATE_IDX {
                     if let Some(output_pos) = last_output_pos {

--- a/src/bytewise/iter.rs
+++ b/src/bytewise/iter.rs
@@ -276,7 +276,7 @@ where
         let haystack = self.haystack.as_ref();
         'a: loop {
             for (pos, &c) in haystack.iter().enumerate().skip(self.pos) {
-                // state_id is always smaller than self.pma.states.len() because
+                // state_id is always smaller than self.pma.leftmost_states.len() because
                 // self.pma.next_state_id_leftmost_unchecked() ensures to return such a value.
                 state_id = unsafe { self.pma.next_state_id_leftmost_unchecked(state_id, c) };
                 if state_id == ROOT_STATE_IDX {
@@ -306,7 +306,7 @@ where
                     }
                 } else if let Some(output_pos) = unsafe {
                     self.pma
-                        .states
+                        .leftmost_states
                         .get_unchecked(usize::from_u32(state_id))
                         .output_pos()
                 } {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -417,7 +417,7 @@ impl Serializable for MatchKind {
 /// let m = it.next().unwrap();
 /// assert_eq!((0, 1), (m.start(), m.end()));
 /// ```
-#[derive(Clone, Copy, Default, Debug)]
+#[derive(Clone, Copy, Default, Debug, Eq, Hash, PartialEq)]
 pub struct Empty;
 
 impl From<usize> for Empty {


### PR DESCRIPTION
This branch separates the fail edges into a distinct array within the double-array constructed for leftmost search.

In a leftmost search, if a search fails but a shorter pattern has already been matched, the algorithm returns that match and resets to the root state without traversing the fail edge. Because of this behavior, maintaining a separate array for fail edges improves the cache hit rate compared to embedding them directly within the double-array.

No changes were made to the charwise version, as no significant performance improvements were observed.

As this change introduces breaking API changes, the major version is incremented.

```
words_100/find_leftmost_longest/daachorse/bytewise/u32
                        time:   [3.3238 ms 3.3296 ms 3.3356 ms]
                        change: [-18.699% -18.494% -18.293%] (p = 0.00 < 0.05)
                        Performance has improved.

words_5000/find_leftmost_longest/daachorse/bytewise/u32
                        time:   [3.6670 ms 3.6694 ms 3.6720 ms]
                        change: [-14.480% -14.323% -14.168%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild

words_15000/find_leftmost_longest/daachorse/bytewise/u32
                        time:   [3.6779 ms 3.6818 ms 3.6862 ms]
                        change: [-12.117% -11.939% -11.733%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe

words_100000/find_leftmost_longest/daachorse/bytewise/u32
                        time:   [4.2412 ms 4.2515 ms 4.2621 ms]
                        change: [-6.7286% -6.3626% -6.0081%] (p = 0.00 < 0.05)
                        Performance has improved.

cl100k/find_leftmost_longest/daachorse/bytewise/u32
                        time:   [5.3596 ms 5.3694 ms 5.3795 ms]
                        change: [-9.5948% -9.4300% -9.2540%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 17 outliers among 100 measurements (17.00%)
  16 (16.00%) high mild
  1 (1.00%) high severe

o200k/find_leftmost_longest/daachorse/bytewise/u32
                        time:   [5.4721 ms 5.4773 ms 5.4824 ms]
                        change: [-10.677% -10.578% -10.477%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild

unidic/find_leftmost_longest/daachorse/bytewise/u32
                        time:   [8.3594 ms 8.3671 ms 8.3749 ms]
                        change: [-9.0033% -8.9042% -8.7928%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

words_100/find_leftmost_first/daachorse/bytewise/u32
                        time:   [3.2376 ms 3.2414 ms 3.2469 ms]
                        change: [-20.668% -20.494% -20.300%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

words_5000/find_leftmost_first/daachorse/bytewise/u32
                        time:   [3.4564 ms 3.4582 ms 3.4600 ms]
                        change: [-19.043% -18.907% -18.773%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild

words_15000/find_leftmost_first/daachorse/bytewise/u32
                        time:   [3.5460 ms 3.5481 ms 3.5501 ms]
                        change: [-14.841% -14.763% -14.680%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

words_100000/find_leftmost_first/daachorse/bytewise/u32
                        time:   [3.9612 ms 3.9652 ms 3.9691 ms]
                        change: [-6.9158% -6.6569% -6.3822%] (p = 0.00 < 0.05)
                        Performance has improved.

cl100k/find_leftmost_first/daachorse/bytewise/u32
                        time:   [3.8067 ms 3.8139 ms 3.8222 ms]
                        change: [-7.3342% -7.0797% -6.8006%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low severe
  3 (3.00%) low mild
  1 (1.00%) high severe

o200k/find_leftmost_first/daachorse/bytewise/u32
                        time:   [3.6471 ms 3.6522 ms 3.6571 ms]
                        change: [-14.383% -14.157% -13.946%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 18 outliers among 100 measurements (18.00%)
  18 (18.00%) low mild

unidic/find_leftmost_first/daachorse/bytewise/u32
                        time:   [2.6112 ms 2.6137 ms 2.6162 ms]
                        change: [-18.711% -18.601% -18.492%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
```