### PR TITLE
Add profile-guided layout optimization (PGLO) feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ exclude = [".*"]
 [dependencies]
 
 [dev-dependencies]
+rand = "0.9"
 
 [features]
 default = ["alloc"]

--- a/src/build_helper.rs
+++ b/src/build_helper.rs
@@ -7,8 +7,23 @@ use crate::utils::FromU32;
 use crate::{DEAD_STATE_IDX, ROOT_STATE_IDX};
 
 /// Access counts of automaton states collected by scanning documents.
+///
+/// Each array is indexed by an NFA state id, and the counts represent how many times the
+/// matching loop reads the double-array element where the state is placed. `states[i]` below
+/// denotes the double-array element of the state `i`.
 pub struct Profile {
+    /// The number of reads of `states[i]` itself:
+    ///
+    /// - `states[i].base` and `states[i].fail` where `i` is the parent state
+    /// - `states[i].check` and `states[i].output_pos` where `i` is the child state
+    ///
+    /// Since the position of `states[i]` is decided by the placement of the sibling group
+    /// containing `i` as a child, this count is added to the weight of that group.
     pub visits: Vec<usize>,
+    /// The number of reads of `states[base(i) ^ c]` where the label `c` has no edge from the
+    /// state `i`, i.e., probes rejected by CHECK values. Such elements always fall within the
+    /// aligned block where the children of `i` are placed, so this count is added to the
+    /// weight of the sibling group of those children.
     pub probes: Vec<usize>,
 }
 
@@ -21,10 +36,24 @@ impl Profile {
     }
 }
 
-/// A group of sibling states sharing a single BASE value.
+/// A group of sibling states sharing a single BASE value, which is the unit of placement in
+/// double-array construction: [`BuildHelper::new()`] assigns a BASE value to each group and
+/// places all of its children at `base ^ label` within a single aligned block.
+///
+/// Groups are enumerated by `NfaBuilder::sibling_groups()` and sorted in descending order of
+/// weights so that frequently accessed groups are packed at smaller indices.
 pub struct SiblingGroup {
+    /// The NFA state id of the parent state whose outgoing edges form this group. After the
+    /// placement, the BASE value assigned to this group is recorded in
+    /// [`BuildHelper::bases`]`[parent]`.
     pub parent: u32,
+    /// Pairs `(label, child)` for each outgoing edge of the parent, where `label` is the value
+    /// used for addressing in the double array (a byte value in the byte-wise version or a
+    /// mapped code value in the character-wise version) and `child` is the NFA state id of the
+    /// child state, which is placed at the index `base ^ label`.
     pub children: Vec<(u32, u32)>,
+    /// The total number of reads of the elements in the block where this group is placed:
+    /// `probes[parent] + Σ visits[child]` (see [`Profile`]).
     pub weight: usize,
 }
 

--- a/src/build_helper.rs
+++ b/src/build_helper.rs
@@ -41,9 +41,9 @@ impl Profile {
     }
 }
 
-/// A group of sibling states sharing a single BASE value, which is the unit of placement in
-/// double-array construction: [`BuildHelper::new()`] assigns a BASE value to each group and
-/// places all of its children at `base ^ label` within a single aligned block.
+/// A group of sibling states, which is the unit of placement in double-array construction.
+/// [`BuildHelper::new()`] assigns a BASE value to each group and places all of its children at
+/// `base ^ label` within a single aligned block.
 ///
 /// Groups are enumerated by `NfaBuilder::sibling_groups()` and sorted in descending order of
 /// weights so that frequently accessed groups are packed at smaller indices.
@@ -92,8 +92,10 @@ impl BuildHelper {
     /// All edge labels must be smaller than `block_len`, which must be a power of two, so that
     /// all children of a group stay within a single aligned block. When `track_bases` is true,
     /// BASE values are additionally kept unique among groups; the byte-wise version requires
-    /// this because its CHECK values are edge labels, whereas the character-wise version stores
-    /// parent indices in CHECK and can safely share a BASE value among multiple states.
+    /// this because its CHECK values are edge labels, so a probe could falsely accept a child
+    /// of another parent placed at the same BASE value. The character-wise version stores
+    /// parent indices in CHECK and stays correct even if different parent states are assigned
+    /// an equal BASE value.
     ///
     /// # Panics
     ///

--- a/src/build_helper.rs
+++ b/src/build_helper.rs
@@ -74,7 +74,7 @@ impl BuildHelper {
         assert_ne!(capacity, 0);
 
         let mut helper = Self {
-            items: Vec::with_capacity(usize::from_u32(capacity)),
+            items: vec![],
             block_len,
             num_free_blocks,
             num_blocks: 0,

--- a/src/build_helper.rs
+++ b/src/build_helper.rs
@@ -11,6 +11,7 @@ use crate::{DEAD_STATE_IDX, ROOT_STATE_IDX};
 /// Each array is indexed by an NFA state id, and the counts represent how many times the
 /// matching loop reads the double-array element where the state is placed. `states[i]` below
 /// denotes the double-array element of the state `i`.
+#[derive(Default)]
 pub struct Profile {
     /// The number of reads of `states[i]` itself:
     ///
@@ -28,11 +29,15 @@ pub struct Profile {
 }
 
 impl Profile {
-    pub fn new(len: usize) -> Self {
-        Self {
-            visits: vec![0; len],
-            probes: vec![0; len],
-        }
+    /// Checks if no corpus has been scanned.
+    pub fn is_empty(&self) -> bool {
+        self.visits.is_empty()
+    }
+
+    /// Allocates the counters for `len` states, initialized to zero.
+    pub fn resize(&mut self, len: usize) {
+        self.visits.resize(len, 0);
+        self.probes.resize(len, 0);
     }
 }
 

--- a/src/build_helper.rs
+++ b/src/build_helper.rs
@@ -8,8 +8,8 @@ use crate::{DEAD_STATE_IDX, ROOT_STATE_IDX};
 
 /// Access counts of automaton states collected by scanning documents.
 pub struct Profile {
-    pub visits: Vec<u64>,
-    pub probes: Vec<u64>,
+    pub visits: Vec<usize>,
+    pub probes: Vec<usize>,
 }
 
 impl Profile {
@@ -25,7 +25,7 @@ impl Profile {
 pub struct SiblingGroup {
     pub parent: u32,
     pub children: Vec<(u32, u32)>,
-    pub weight: u64,
+    pub weight: usize,
 }
 
 /// Helper struct in double-array construction to maintain indices of vacant elements and

--- a/src/build_helper.rs
+++ b/src/build_helper.rs
@@ -1,65 +1,118 @@
 use core::num::NonZeroU32;
-use core::ops::Range;
 
 use alloc::vec::Vec;
 
 use crate::errors::{DaachorseError, Result};
 use crate::utils::FromU32;
+use crate::{DEAD_STATE_IDX, ROOT_STATE_IDX};
+
+/// Access counts of automaton states collected by scanning documents.
+pub struct Profile {
+    pub visits: Vec<u64>,
+    pub probes: Vec<u64>,
+}
+
+impl Profile {
+    pub fn new(len: usize) -> Self {
+        Self {
+            visits: vec![0; len],
+            probes: vec![0; len],
+        }
+    }
+}
+
+/// A group of sibling states sharing a single BASE value.
+pub struct SiblingGroup {
+    pub parent: u32,
+    pub children: Vec<(u32, u32)>,
+    pub weight: u64,
+}
 
 /// Helper struct in double-array construction to maintain indices of vacant elements and
 /// unused BASE values.
 ///
 /// This struct manages array elements in fixed-size blocks and supports extending the array
-/// block by block. Given a constant parameter N, this struct maintains information for only
-/// the last N blocks and drops the others as the array is extended. Such trailing blocks are
-/// called *active blocks*.
+/// block by block. The helper starts in the exhaustive mode, where the whole array is scanned
+/// so that groups are packed at the smallest vacant indices. Once [`Self::enable_window()`] is
+/// called, only the vacant indices in the last `num_free_blocks` blocks are scanned; vacant
+/// indices dropped from the window are left unused, which slightly increases the memory usage
+/// but bounds the construction time.
 pub struct BuildHelper {
     items: Vec<ListItem>,
     block_len: u32,
     num_free_blocks: u32,
     num_blocks: u32,
     head_idx: Option<u32>,
+    windowed: bool,
+    pub idx_map: Vec<u32>,
+    pub bases: Vec<Option<NonZeroU32>>,
 }
 
 impl BuildHelper {
-    /// Creates a helper struct that handles the last `block_len * num_free_blocks` elements.
+    /// Creates a helper holding the vacancy information of a double array and places the sibling
+    /// groups in the given order, packing each group at the smallest vacant position.
+    ///
+    /// All edge labels must be smaller than `block_len`, which must be a power of two, so that
+    /// all children of a group stay within a single aligned block. When `track_bases` is true,
+    /// BASE values are additionally kept unique among groups; the byte-wise version requires
+    /// this because its CHECK values are edge labels, whereas the character-wise version stores
+    /// parent indices in CHECK and can safely share a BASE value among multiple states.
     ///
     /// # Panics
     ///
     /// Panics if block_len == 0 || num_free_blocks == 0.
-    pub fn new(block_len: u32, num_free_blocks: u32) -> Result<Self> {
+    pub fn new(
+        groups: &[SiblingGroup],
+        num_nfa_states: usize,
+        block_len: u32,
+        num_free_blocks: u32,
+        track_bases: bool,
+    ) -> Result<Self> {
         let capacity = block_len.checked_mul(num_free_blocks).ok_or_else(|| {
             DaachorseError::automaton_scale("block_len * num_free_blocks", u32::MAX)
         })?;
-        let capacity = usize::from_u32(capacity);
         assert_ne!(capacity, 0);
 
-        Ok(Self {
-            items: vec![ListItem::default(); capacity],
+        let mut helper = Self {
+            items: Vec::with_capacity(usize::from_u32(capacity)),
             block_len,
             num_free_blocks,
             num_blocks: 0,
             head_idx: None,
-        })
+            windowed: false,
+            idx_map: vec![DEAD_STATE_IDX; num_nfa_states],
+            bases: vec![None; num_nfa_states],
+        };
+        helper.push_block()?;
+        helper.use_index(ROOT_STATE_IDX);
+        helper.use_index(DEAD_STATE_IDX);
+        helper.idx_map[usize::from_u32(ROOT_STATE_IDX)] = ROOT_STATE_IDX;
+        helper.idx_map[usize::from_u32(DEAD_STATE_IDX)] = DEAD_STATE_IDX;
+        let mut labels = vec![];
+        for group in groups {
+            if group.weight == 0 && !helper.windowed {
+                helper.enable_window();
+            }
+            labels.clear();
+            labels.extend(group.children.iter().map(|&(c, _)| c));
+            let base = helper.find_base(&labels)?;
+            if track_bases {
+                helper.use_base(base);
+            }
+            for &(c, child_id) in &group.children {
+                let child_idx = base.get() ^ c;
+                helper.use_index(child_idx);
+                helper.idx_map[usize::from_u32(child_id)] = child_idx;
+            }
+            helper.bases[usize::from_u32(group.parent)] = Some(base);
+        }
+        Ok(helper)
     }
 
     /// Gets the number of current double-array elements.
     #[inline(always)]
     pub const fn num_elements(&self) -> u32 {
         self.num_blocks * self.block_len
-    }
-
-    /// Gets the index range of elements in the active blocks.
-    #[inline(always)]
-    pub const fn active_index_range(&self) -> Range<u32> {
-        let r = self.active_block_range();
-        r.start * self.block_len..r.end * self.block_len
-    }
-
-    /// Gets the block index range in the active blocks.
-    #[inline(always)]
-    pub const fn active_block_range(&self) -> Range<u32> {
-        self.num_blocks.saturating_sub(self.num_free_blocks)..self.num_blocks
     }
 
     /// Creates an iterator to visit vacant indices in the active blocks.
@@ -80,69 +133,47 @@ impl BuildHelper {
     }
 
     /// Checks if the BASE value is used.
-    ///
-    /// # Panics
-    ///
-    /// Panics if active_index_range().contains(&base) == false.
     #[inline(always)]
     pub fn is_used_base(&self, base: u32) -> bool {
         self.get_ref(base).is_used_base()
     }
 
     /// Checks if the index is used.
-    ///
-    /// # Panics
-    ///
-    /// Panics if active_index_range().contains(&idx) == false.
     #[inline(always)]
     pub fn is_used_index(&self, idx: u32) -> bool {
         self.get_ref(idx).is_used_index()
     }
 
     /// Uses the BASE value.
-    ///
-    /// # Panics
-    ///
-    /// Panics if active_index_range().contains(&base) == false.
     #[inline(always)]
-    pub fn use_base(&mut self, base: NonZeroU32) {
+    fn use_base(&mut self, base: NonZeroU32) {
         self.get_mut(base.get()).use_base();
     }
 
     /// Uses the index.
-    ///
-    /// # Panics
-    ///
-    /// Panics if active_index_range().contains(&idx) == false.
     #[inline(always)]
-    pub fn use_index(&mut self, idx: u32) {
+    fn use_index(&mut self, idx: u32) {
         debug_assert!(!self.get_ref(idx).is_used_index());
         self.get_mut(idx).use_index();
+        self.unlink(idx);
+    }
 
-        let next = self.get_mut(idx).next();
-        let prev = self.get_mut(idx).prev();
+    /// Removes the index from the vacant list without marking it used, so that it is no longer
+    /// scanned but is still treated as vacant by `is_used_index()`.
+    fn unlink(&mut self, idx: u32) {
+        let next = self.get_ref(idx).next();
+        let prev = self.get_ref(idx).prev();
         *self.get_mut(prev).next_mut() = next;
         *self.get_mut(next).prev_mut() = prev;
-
         if self.head_idx.unwrap() == idx {
             self.head_idx = Some(next).filter(|&x| x != idx);
         }
     }
 
     /// Extends the array by pushing a block back.
-    pub fn push_block(&mut self) -> Result<()> {
+    fn push_block(&mut self) -> Result<()> {
         if self.num_elements() > u32::MAX - self.block_len {
             return Err(DaachorseError::automaton_scale("num_elements", u32::MAX));
-        }
-
-        if let Some(closed_block) = self.dropped_block() {
-            let end_idx = (closed_block + 1) * self.block_len;
-            while let Some(head_idx) = self.head_idx {
-                if end_idx <= head_idx {
-                    break;
-                }
-                self.use_index(head_idx);
-            }
         }
 
         let old_len = self.num_elements();
@@ -150,9 +181,10 @@ impl BuildHelper {
 
         // Update the active index range.
         self.num_blocks += 1;
+        self.items
+            .resize(usize::from_u32(new_len), ListItem::default());
 
         for idx in old_len..new_len {
-            self.reset(idx);
             *self.get_mut(idx).next_mut() = idx + 1;
             *self.get_mut(idx).prev_mut() = idx.wrapping_sub(1);
         }
@@ -169,41 +201,58 @@ impl BuildHelper {
             self.head_idx = Some(old_len);
         }
 
+        if self.windowed {
+            self.prune();
+        }
         Ok(())
     }
 
-    /// Returns the index of an active block that will be dropped in the next `push_block`.
-    #[inline(always)]
-    pub fn dropped_block(&self) -> Option<u32> {
-        (self.capacity() <= self.num_elements()).then(|| self.active_block_range().start)
+    /// Switches to the windowed mode, where only the vacant indices in the last
+    /// `num_free_blocks` blocks are scanned.
+    fn enable_window(&mut self) {
+        self.windowed = true;
+        self.prune();
     }
 
-    #[inline(always)]
-    fn capacity(&self) -> u32 {
-        u32::try_from(self.items.len()).unwrap()
+    /// Drops the vacant indices that have fallen out of the window from the list. Since the
+    /// list is kept in ascending order of indices, it suffices to unlink from the head.
+    fn prune(&mut self) {
+        let boundary = self.num_blocks.saturating_sub(self.num_free_blocks) * self.block_len;
+        while let Some(head_idx) = self.head_idx {
+            if head_idx >= boundary {
+                break;
+            }
+            self.unlink(head_idx);
+        }
     }
 
-    #[inline(always)]
-    fn reset(&mut self, idx: u32) {
-        let offset = self.offset(idx);
-        self.items[offset] = ListItem::default();
+    /// Finds the smallest vacant placement for the given labels, extending the array if needed.
+    ///
+    /// The scan visits the vacant indices in ascending order, so the placement is the densest
+    /// first-fit over the exhaustive or windowed scan range.
+    fn find_base(&mut self, labels: &[u32]) -> Result<NonZeroU32> {
+        loop {
+            for idx in self.vacant_iter() {
+                let base = idx ^ labels[0];
+                if base != 0
+                    && !self.is_used_base(base)
+                    && labels.iter().all(|&c| !self.is_used_index(base ^ c))
+                {
+                    return Ok(NonZeroU32::new(base).unwrap());
+                }
+            }
+            self.push_block()?;
+        }
     }
 
     #[inline(always)]
     fn get_ref(&self, idx: u32) -> &ListItem {
-        &self.items[self.offset(idx)]
+        &self.items[usize::from_u32(idx)]
     }
 
     #[inline(always)]
     fn get_mut(&mut self, idx: u32) -> &mut ListItem {
-        let offset = self.offset(idx);
-        &mut self.items[offset]
-    }
-
-    #[inline(always)]
-    fn offset(&self, idx: u32) -> usize {
-        assert!(self.active_index_range().contains(&idx));
-        usize::from_u32(idx % self.capacity())
+        &mut self.items[usize::from_u32(idx)]
     }
 }
 

--- a/src/build_helper.rs
+++ b/src/build_helper.rs
@@ -28,19 +28,22 @@ pub struct SiblingGroup {
     pub weight: usize,
 }
 
+// The number of trailing blocks scanned in the windowed mode. The packing density saturates
+// with a small window, whereas a larger window only slows down the construction.
+const NUM_FREE_BLOCKS: u32 = 16;
+
 /// Helper struct in double-array construction to maintain indices of vacant elements and
 /// unused BASE values.
 ///
 /// This struct manages array elements in fixed-size blocks and supports extending the array
 /// block by block. The helper starts in the exhaustive mode, where the whole array is scanned
 /// so that groups are packed at the smallest vacant indices. Once [`Self::enable_window()`] is
-/// called, only the vacant indices in the last `num_free_blocks` blocks are scanned; vacant
+/// called, only the vacant indices in the last [`NUM_FREE_BLOCKS`] blocks are scanned; vacant
 /// indices dropped from the window are left unused, which slightly increases the memory usage
 /// but bounds the construction time.
 pub struct BuildHelper {
     items: Vec<ListItem>,
     block_len: u32,
-    num_free_blocks: u32,
     num_blocks: u32,
     head_idx: Option<u32>,
     windowed: bool,
@@ -60,23 +63,18 @@ impl BuildHelper {
     ///
     /// # Panics
     ///
-    /// Panics if block_len == 0 || num_free_blocks == 0.
+    /// Panics if block_len == 0.
     pub fn new(
         groups: &[SiblingGroup],
         num_nfa_states: usize,
         block_len: u32,
-        num_free_blocks: u32,
         track_bases: bool,
     ) -> Result<Self> {
-        let capacity = block_len.checked_mul(num_free_blocks).ok_or_else(|| {
-            DaachorseError::automaton_scale("block_len * num_free_blocks", u32::MAX)
-        })?;
-        assert_ne!(capacity, 0);
+        assert_ne!(block_len, 0);
 
         let mut helper = Self {
             items: vec![],
             block_len,
-            num_free_blocks,
             num_blocks: 0,
             head_idx: None,
             windowed: false,
@@ -208,7 +206,7 @@ impl BuildHelper {
     }
 
     /// Switches to the windowed mode, where only the vacant indices in the last
-    /// `num_free_blocks` blocks are scanned.
+    /// [`NUM_FREE_BLOCKS`] blocks are scanned.
     fn enable_window(&mut self) {
         self.windowed = true;
         self.prune();
@@ -217,7 +215,7 @@ impl BuildHelper {
     /// Drops the vacant indices that have fallen out of the window from the list. Since the
     /// list is kept in ascending order of indices, it suffices to unlink from the head.
     fn prune(&mut self) {
-        let boundary = self.num_blocks.saturating_sub(self.num_free_blocks) * self.block_len;
+        let boundary = self.num_blocks.saturating_sub(NUM_FREE_BLOCKS) * self.block_len;
         while let Some(head_idx) = self.head_idx {
             if head_idx >= boundary {
                 break;

--- a/src/build_helper.rs
+++ b/src/build_helper.rs
@@ -49,8 +49,8 @@ impl Profile {
 /// weights so that frequently accessed groups are packed at smaller indices.
 pub struct SiblingGroup {
     /// The NFA state id of the parent state whose outgoing edges form this group. After the
-    /// placement, the BASE value assigned to this group is recorded in
-    /// [`BuildHelper::bases`]`[parent]`.
+    /// placement, the BASE value assigned to this group is recorded in the `parent`-th element
+    /// of [`BuildHelper::bases`].
     pub parent: u32,
     /// Pairs `(label, child)` for each outgoing edge of the parent, where `label` is the value
     /// used for addressing in the double array (a byte value in the byte-wise version or a

--- a/src/build_helper.rs
+++ b/src/build_helper.rs
@@ -149,7 +149,9 @@ impl BuildHelper {
         self.num_blocks * self.block_len
     }
 
-    /// Creates an iterator to visit vacant indices in the active blocks.
+    /// Creates an iterator to visit vacant indices in the scan range in ascending order: the
+    /// whole array in the exhaustive mode, or the last [`NUM_FREE_BLOCKS`] blocks in the
+    /// windowed mode.
     #[inline(always)]
     pub const fn vacant_iter(&self) -> VacantIter<'_> {
         VacantIter {
@@ -194,9 +196,16 @@ impl BuildHelper {
 
     /// Removes the index from the vacant list without marking it used, so that it is no longer
     /// scanned but is still treated as vacant by `is_used_index()`.
+    ///
+    /// The index must be linked in the list; unlinking a pruned index would corrupt the list
+    /// through its stale neighbor pointers. `find_base()` never chooses such an index because
+    /// the window boundary is block-aligned and all children of a group stay within the aligned
+    /// block of the returned BASE value.
     fn unlink(&mut self, idx: u32) {
         let next = self.get_ref(idx).next();
         let prev = self.get_ref(idx).prev();
+        debug_assert_eq!(self.get_ref(prev).next(), idx);
+        debug_assert_eq!(self.get_ref(next).prev(), idx);
         *self.get_mut(prev).next_mut() = next;
         *self.get_mut(next).prev_mut() = prev;
         if self.head_idx.unwrap() == idx {
@@ -213,7 +222,6 @@ impl BuildHelper {
         let old_len = self.num_elements();
         let new_len = old_len + self.block_len;
 
-        // Update the active index range.
         self.num_blocks += 1;
         self.items
             .resize(usize::from_u32(new_len), ListItem::default());

--- a/src/bytewise.rs
+++ b/src/bytewise.rs
@@ -9,7 +9,6 @@ use core::num::NonZeroU32;
 
 use alloc::vec::Vec;
 
-use crate::build_helper::BuildHelper;
 pub use crate::bytewise::builder::DoubleArrayAhoCorasickBuilder;
 use crate::bytewise::iter::{
     FindIterator, FindOverlappingIterator, FindOverlappingNoSuffixIterator, FindOverlappingStepper,
@@ -19,12 +18,10 @@ use crate::errors::{DaachorseError, Result};
 use crate::intpack::{U24nU8, U24};
 use crate::serializer::{Serializable, SerializableVec};
 use crate::utils::FromU32;
-use crate::{Empty, MatchKind, Output};
+use crate::{Empty, MatchKind, Output, DEAD_STATE_IDX, ROOT_STATE_IDX};
 
-// The root index position.
-const ROOT_STATE_IDX: u32 = 0;
-// The dead index position.
-const DEAD_STATE_IDX: u32 = 1;
+// The length of each double-array block.
+pub(crate) const BLOCK_LEN: u32 = 256;
 
 /// A fast multiple pattern match automaton implemented with the Aho-Corasick algorithm and compact
 /// double-array data structure.
@@ -889,7 +886,7 @@ impl<V> DoubleArrayAhoCorasick<V> {
             num_states,
             root_table,
         };
-        let block_len = 256;
+        let block_len = usize::from_u32(BLOCK_LEN);
         let outputs_len = pma.outputs.len();
         if pma.match_kind.is_leftmost() {
             if !pma.states.is_empty() {

--- a/src/bytewise/builder.rs
+++ b/src/bytewise/builder.rs
@@ -225,7 +225,7 @@ impl DoubleArrayAhoCorasickBuilder {
     {
         let nfa = self.build_sparse_nfa(patvals)?;
         let profile = if self.corpus.is_empty() {
-            Profile::new(nfa.states.len())
+            Profile::default()
         } else {
             self.profile_corpus(&nfa)
         };
@@ -289,7 +289,8 @@ impl DoubleArrayAhoCorasickBuilder {
     where
         V: Copy,
     {
-        let mut profile = Profile::new(nfa.states.len());
+        let mut profile = Profile::default();
+        profile.resize(nfa.states.len());
         // The standard matching handles the root transitions with a dense table.
         let dense_root = !self.match_kind.is_leftmost();
         for haystack in &self.corpus {

--- a/src/bytewise/builder.rs
+++ b/src/bytewise/builder.rs
@@ -1,14 +1,12 @@
 use alloc::vec::Vec;
 
 use crate::build_helper::{BuildHelper, Profile};
-use crate::bytewise::{
-    DoubleArrayAhoCorasick, MatchKind, State, BLOCK_LEN, DEAD_STATE_IDX, ROOT_STATE_IDX,
-};
+use crate::bytewise::{DoubleArrayAhoCorasick, MatchKind, State, BLOCK_LEN};
 use crate::errors::{DaachorseError, Result};
 use crate::intpack::U24;
 use crate::nfa_builder::{NfaBuilder, DEAD_STATE_ID};
 use crate::utils::FromU32;
-use crate::Empty;
+use crate::{Empty, DEAD_STATE_IDX, ROOT_STATE_IDX};
 
 // Specialized [`NfaBuilder`] handling labels of `u8`.
 type BytewiseNfaBuilder<V> = NfaBuilder<u8, V>;

--- a/src/bytewise/builder.rs
+++ b/src/bytewise/builder.rs
@@ -16,7 +16,6 @@ pub struct DoubleArrayAhoCorasickBuilder {
     states: Vec<State<u32>>,
     match_kind: MatchKind,
     corpus: Vec<Vec<u8>>,
-    num_free_blocks: u32,
 }
 
 impl Default for DoubleArrayAhoCorasickBuilder {
@@ -54,7 +53,6 @@ impl DoubleArrayAhoCorasickBuilder {
             states: vec![],
             match_kind: MatchKind::Standard,
             corpus: vec![],
-            num_free_blocks: 64,
         }
     }
 
@@ -88,29 +86,6 @@ impl DoubleArrayAhoCorasickBuilder {
         self
     }
 
-    /// Specifies the number of trailing blocks to use when searching for base values.
-    ///
-    /// The smaller the number is, the faster the construction time will be;
-    /// however, the memory efficiency can be degraded.
-    ///
-    /// When a corpus is specified with [`Self::corpus()`], states accessed in scanning the
-    /// corpus are placed by scanning all the blocks regardless of this value, and only the
-    /// remaining states are placed using the trailing blocks.
-    ///
-    /// # Arguments
-    ///
-    /// * `n` - The number of last blocks.
-    ///
-    /// # Panics
-    ///
-    /// `n` must be greater than or equal to 1.
-    #[must_use]
-    pub fn num_free_blocks(mut self, n: u32) -> Self {
-        assert!(n >= 1);
-        self.num_free_blocks = n;
-        self
-    }
-
     /// Specifies a corpus of sample documents for the profile-guided layout optimization.
     ///
     /// States frequently accessed in scanning the corpus are packed densely at small indices
@@ -118,8 +93,8 @@ impl DoubleArrayAhoCorasickBuilder {
     /// The corpus never changes match results, only the memory layout of the automaton.
     ///
     /// Since the states accessed in scanning the corpus are placed by scanning all the blocks
-    /// (see [`Self::num_free_blocks()`]), the construction time can increase, especially when
-    /// the corpus covers most states of a large pattern set.
+    /// of the double array, the construction time can increase, especially when the corpus
+    /// covers most states of a large pattern set.
     ///
     /// # Arguments
     ///
@@ -332,13 +307,7 @@ impl DoubleArrayAhoCorasickBuilder {
         V: Copy,
     {
         let groups = nfa.sibling_groups(profile, u32::from);
-        let helper = BuildHelper::new(
-            &groups,
-            nfa.states.len(),
-            BLOCK_LEN,
-            self.num_free_blocks,
-            true,
-        )?;
+        let helper = BuildHelper::new(&groups, nfa.states.len(), BLOCK_LEN, true)?;
 
         self.states
             .resize(usize::from_u32(helper.num_elements()), State::default());

--- a/src/bytewise/builder.rs
+++ b/src/bytewise/builder.rs
@@ -6,7 +6,7 @@ use crate::bytewise::{
 };
 use crate::errors::{DaachorseError, Result};
 use crate::intpack::U24;
-use crate::nfa_builder::{NfaBuilder, DEAD_STATE_ID, ROOT_STATE_ID};
+use crate::nfa_builder::{NfaBuilder, DEAD_STATE_ID};
 use crate::utils::FromU32;
 use crate::Empty;
 
@@ -56,7 +56,7 @@ impl DoubleArrayAhoCorasickBuilder {
             states: vec![],
             match_kind: MatchKind::Standard,
             corpus: vec![],
-            num_free_blocks: 16,
+            num_free_blocks: 64,
         }
     }
 
@@ -95,9 +95,9 @@ impl DoubleArrayAhoCorasickBuilder {
     /// The smaller the number is, the faster the construction time will be;
     /// however, the memory efficiency can be degraded.
     ///
-    /// A fixed length of memory is allocated in proportion to this value in construction. If an
-    /// allocation error occurs during building the automaton even though the pattern set is small,
-    /// try setting a smaller value.
+    /// When a corpus is specified with [`Self::corpus()`], states accessed in scanning the
+    /// corpus are placed by scanning all the blocks regardless of this value, and only the
+    /// remaining states are placed using the trailing blocks.
     ///
     /// # Arguments
     ///
@@ -114,6 +114,14 @@ impl DoubleArrayAhoCorasickBuilder {
     }
 
     /// Specifies a corpus of sample documents for the profile-guided layout optimization.
+    ///
+    /// States frequently accessed in scanning the corpus are packed densely at small indices
+    /// so that matching on documents similar to the corpus becomes more cache-efficient.
+    /// The corpus never changes match results, only the memory layout of the automaton.
+    ///
+    /// Since the states accessed in scanning the corpus are placed by scanning all the blocks
+    /// (see [`Self::num_free_blocks()`]), the construction time can increase, especially when
+    /// the corpus covers most states of a large pattern set.
     ///
     /// # Arguments
     ///
@@ -312,10 +320,7 @@ impl DoubleArrayAhoCorasickBuilder {
         // The standard matching handles the root transitions with a dense table.
         let dense_root = !self.match_kind.is_leftmost();
         for haystack in &self.corpus {
-            let mut state_id = ROOT_STATE_ID;
-            for &c in haystack {
-                state_id = nfa.profile_step(state_id, c, &mut profile, dense_root);
-            }
+            nfa.profile_haystack(haystack, &mut profile, dense_root, |_| true);
         }
         profile
     }

--- a/src/bytewise/builder.rs
+++ b/src/bytewise/builder.rs
@@ -1,18 +1,14 @@
-use core::num::NonZeroU32;
-
 use alloc::vec::Vec;
 
+use crate::build_helper::{BuildHelper, Profile};
 use crate::bytewise::{
-    BuildHelper, DoubleArrayAhoCorasick, MatchKind, State, DEAD_STATE_IDX, ROOT_STATE_IDX,
+    DoubleArrayAhoCorasick, MatchKind, State, BLOCK_LEN, DEAD_STATE_IDX, ROOT_STATE_IDX,
 };
 use crate::errors::{DaachorseError, Result};
 use crate::intpack::U24;
 use crate::nfa_builder::{NfaBuilder, DEAD_STATE_ID, ROOT_STATE_ID};
 use crate::utils::FromU32;
 use crate::Empty;
-
-// The length of each double-array block.
-const BLOCK_LEN: u32 = 256;
 
 // Specialized [`NfaBuilder`] handling labels of `u8`.
 type BytewiseNfaBuilder<V> = NfaBuilder<u8, V>;
@@ -21,6 +17,7 @@ type BytewiseNfaBuilder<V> = NfaBuilder<u8, V>;
 pub struct DoubleArrayAhoCorasickBuilder {
     states: Vec<State<u32>>,
     match_kind: MatchKind,
+    corpus: Vec<Vec<u8>>,
     num_free_blocks: u32,
 }
 
@@ -58,6 +55,7 @@ impl DoubleArrayAhoCorasickBuilder {
         Self {
             states: vec![],
             match_kind: MatchKind::Standard,
+            corpus: vec![],
             num_free_blocks: 16,
         }
     }
@@ -112,6 +110,43 @@ impl DoubleArrayAhoCorasickBuilder {
     pub fn num_free_blocks(mut self, n: u32) -> Self {
         assert!(n >= 1);
         self.num_free_blocks = n;
+        self
+    }
+
+    /// Specifies a corpus of sample documents for the profile-guided layout optimization.
+    ///
+    /// # Arguments
+    ///
+    /// * `haystacks` - Sample documents to be scanned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use daachorse::DoubleArrayAhoCorasickBuilder;
+    ///
+    /// let patterns = vec!["bcd", "ab", "a"];
+    /// let pma = DoubleArrayAhoCorasickBuilder::new()
+    ///     .corpus(["abcd"])
+    ///     .build(patterns)
+    ///     .unwrap();
+    ///
+    /// let mut it = pma.find_iter("abcd");
+    ///
+    /// let m = it.next().unwrap();
+    /// assert_eq!((0, 1, 2), (m.start(), m.end(), m.value()));
+    ///
+    /// let m = it.next().unwrap();
+    /// assert_eq!((1, 4, 0), (m.start(), m.end(), m.value()));
+    ///
+    /// assert_eq!(None, it.next());
+    /// ```
+    #[must_use]
+    pub fn corpus<I, P>(mut self, haystacks: I) -> Self
+    where
+        I: IntoIterator<Item = P>,
+        P: AsRef<[u8]>,
+    {
+        self.corpus = haystacks.into_iter().map(|h| h.as_ref().to_vec()).collect();
         self
     }
 
@@ -208,7 +243,12 @@ impl DoubleArrayAhoCorasickBuilder {
         V: Copy,
     {
         let nfa = self.build_sparse_nfa(patvals)?;
-        self.build_double_array(&nfa)?;
+        let profile = if self.corpus.is_empty() {
+            Profile::new(nfa.states.len())
+        } else {
+            self.profile_corpus(&nfa)
+        };
+        self.build_double_array(&nfa, &profile)?;
 
         // -1 is for dead state
         let num_states = u32::try_from(nfa.states.len() - 1)
@@ -264,47 +304,62 @@ impl DoubleArrayAhoCorasickBuilder {
         Ok(nfa)
     }
 
-    fn build_double_array<V>(&mut self, nfa: &BytewiseNfaBuilder<V>) -> Result<()> {
-        let mut helper = self.init_array()?;
-
-        let mut state_id_map = vec![DEAD_STATE_IDX; nfa.states.len()];
-        state_id_map[usize::from_u32(ROOT_STATE_ID)] = ROOT_STATE_IDX;
-
-        // Arranges base & check values
-        let mut stack = vec![ROOT_STATE_ID];
-        let mut labels = vec![];
-
-        while let Some(state_id) = stack.pop() {
-            debug_assert_ne!(state_id, DEAD_STATE_ID);
-            let s = &nfa.states[usize::from_u32(state_id)];
-
-            let state_idx = usize::from_u32(state_id_map[usize::from_u32(state_id)]);
-            debug_assert_ne!(state_idx, usize::from_u32(DEAD_STATE_IDX));
-
-            if s.edges.is_empty() {
-                continue;
+    fn profile_corpus<V>(&self, nfa: &BytewiseNfaBuilder<V>) -> Profile
+    where
+        V: Copy,
+    {
+        let mut profile = Profile::new(nfa.states.len());
+        // The standard matching handles the root transitions with a dense table.
+        let dense_root = !self.match_kind.is_leftmost();
+        for haystack in &self.corpus {
+            let mut state_id = ROOT_STATE_ID;
+            for &c in haystack {
+                state_id = nfa.profile_step(state_id, c, &mut profile, dense_root);
             }
+        }
+        profile
+    }
 
-            labels.clear();
-            s.edges.keys().for_each(|&k| labels.push(k));
+    fn build_double_array<V>(
+        &mut self,
+        nfa: &BytewiseNfaBuilder<V>,
+        profile: &Profile,
+    ) -> Result<()>
+    where
+        V: Copy,
+    {
+        let groups = nfa.sibling_groups(profile, u32::from);
+        let helper = BuildHelper::new(
+            &groups,
+            nfa.states.len(),
+            BLOCK_LEN,
+            self.num_free_blocks,
+            true,
+        )?;
 
-            let base = self.find_base(&labels, &helper);
-            if usize::from_u32(base.get()) >= self.states.len() {
-                self.extend_array(&mut helper)?;
+        self.states
+            .resize(usize::from_u32(helper.num_elements()), State::default());
+        for group in &groups {
+            for &(c, child_id) in &group.children {
+                let child_idx = helper.idx_map[usize::from_u32(child_id)];
+                self.states[usize::from_u32(child_idx)].set_check(u8::try_from(c).unwrap());
             }
-
-            for &(c, child_id) in s.edges.iter() {
-                let child_idx = base.get() ^ u32::from(c);
-                helper.use_index(child_idx);
-                self.states[usize::from_u32(child_idx)].set_check(c);
-                state_id_map[usize::from_u32(child_id)] = child_idx;
-                stack.push(child_id);
-            }
-            self.states[state_idx].set_base(base);
-            helper.use_base(base);
+            // BuildHelper::new() assigns a BASE value to every group.
+            self.states[usize::from_u32(helper.idx_map[usize::from_u32(group.parent)])]
+                .set_base(helper.bases[usize::from_u32(group.parent)].unwrap());
         }
 
-        // Sets fail & output_pos values
+        self.set_fails_and_outputs(nfa, &helper.idx_map)?;
+        self.remove_invalid_checks(&helper);
+
+        Ok(())
+    }
+
+    fn set_fails_and_outputs<V>(
+        &mut self,
+        nfa: &BytewiseNfaBuilder<V>,
+        state_id_map: &[u32],
+    ) -> Result<()> {
         for (i, s) in nfa.states.iter().enumerate() {
             if i == usize::from_u32(DEAD_STATE_ID) {
                 continue;
@@ -324,76 +379,18 @@ impl DoubleArrayAhoCorasickBuilder {
                 self.states[idx].set_fail(fail_idx);
             }
         }
-
-        for closed_block_idx in helper.active_block_range() {
-            self.remove_invalid_checks(closed_block_idx, &helper);
-        }
-        self.states.shrink_to_fit();
-
         Ok(())
     }
 
-    fn init_array(&mut self) -> Result<BuildHelper> {
-        self.states
-            .resize(usize::from_u32(BLOCK_LEN), State::default());
-        let mut helper = BuildHelper::new(BLOCK_LEN, self.num_free_blocks)?;
-        helper.push_block().unwrap();
-        helper.use_index(ROOT_STATE_IDX);
-        helper.use_index(DEAD_STATE_IDX);
-        Ok(helper)
-    }
-
-    #[inline(always)]
-    fn find_base(&self, labels: &[u8], helper: &BuildHelper) -> NonZeroU32 {
-        for idx in helper.vacant_iter() {
-            let base = idx ^ u32::from(labels[0]);
-            if let Some(base) = Self::check_valid_base(base, labels, helper) {
-                return base;
-            }
-        }
-        // len() is not 0 since states has at least BLOCK_LEN items.
-        NonZeroU32::new(u32::try_from(self.states.len()).unwrap()).unwrap()
-    }
-
-    #[inline(always)]
-    fn check_valid_base(base: u32, labels: &[u8], helper: &BuildHelper) -> Option<NonZeroU32> {
-        if helper.is_used_base(base) {
-            return None;
-        }
-        for &c in labels {
-            let idx = base ^ u32::from(c);
-            if helper.is_used_index(idx) {
-                return None;
-            }
-        }
-        NonZeroU32::new(base)
-    }
-
-    fn extend_array(&mut self, helper: &mut BuildHelper) -> Result<()> {
-        if self.states.len() > usize::from_u32(u32::MAX - BLOCK_LEN) {
-            return Err(DaachorseError::automaton_scale("states.len()", u32::MAX));
-        }
-
-        if let Some(closed_block_idx) = helper.dropped_block() {
-            self.remove_invalid_checks(closed_block_idx, helper);
-        }
-
-        helper.push_block()?;
-        self.states.resize(
-            self.states.len() + usize::from_u32(BLOCK_LEN),
-            State::default(),
-        );
-
-        Ok(())
-    }
-
-    /// Embeds valid CHECK values for all vacant elements in the block to avoid invalid transitions.
-    fn remove_invalid_checks(&mut self, block_idx: u32, helper: &BuildHelper) {
-        if let Some(unused_base) = helper.unused_base_in_block(block_idx) {
-            for c in u8::MIN..=u8::MAX {
-                let idx = unused_base ^ u32::from(c);
-                if idx == ROOT_STATE_IDX || idx == DEAD_STATE_IDX || !helper.is_used_index(idx) {
-                    self.states[usize::from_u32(idx)].set_check(c);
+    fn remove_invalid_checks(&mut self, helper: &BuildHelper) {
+        for block_idx in 0..helper.num_elements() / BLOCK_LEN {
+            if let Some(unused_base) = helper.unused_base_in_block(block_idx) {
+                for c in u8::MIN..=u8::MAX {
+                    let idx = unused_base ^ u32::from(c);
+                    if idx == ROOT_STATE_IDX || idx == DEAD_STATE_IDX || !helper.is_used_index(idx)
+                    {
+                        self.states[usize::from_u32(idx)].set_check(c);
+                    }
                 }
             }
         }

--- a/src/bytewise/iter.rs
+++ b/src/bytewise/iter.rs
@@ -4,10 +4,8 @@ use core::iter::Enumerate;
 use core::num::NonZeroU32;
 
 use crate::bytewise::DoubleArrayAhoCorasick;
-use crate::Match;
-
-use crate::bytewise::ROOT_STATE_IDX;
 use crate::utils::FromU32;
+use crate::{Match, ROOT_STATE_IDX};
 
 /// Iterator for some struct that implements [`AsRef<[u8]>`].
 #[doc(hidden)]

--- a/src/charwise.rs
+++ b/src/charwise.rs
@@ -19,12 +19,7 @@ use crate::charwise::mapper::CodeMapper;
 use crate::errors::{DaachorseError, Result};
 use crate::serializer::{Serializable, SerializableVec};
 use crate::utils::FromU32;
-use crate::{MatchKind, Output};
-
-// The root index position.
-const ROOT_STATE_IDX: u32 = 0;
-// The dead index position.
-const DEAD_STATE_IDX: u32 = 1;
+use crate::{MatchKind, Output, DEAD_STATE_IDX, ROOT_STATE_IDX};
 
 /// A fast multiple pattern match automaton implemented with the Aho-Corasick algorithm and
 /// character-wise double-array data structure.
@@ -917,7 +912,7 @@ impl<V> CharwiseDoubleArrayAhoCorasick<V> {
                 return Err(DaachorseError::invalid_automaton());
             }
         }
-        let block_len = usize::from_u32(pma.mapper.alphabet_size().next_power_of_two().max(2));
+        let block_len = usize::from_u32(pma.mapper.block_len());
         if pma.states.is_empty() {
             return Err(DaachorseError::invalid_automaton());
         }

--- a/src/charwise/builder.rs
+++ b/src/charwise/builder.rs
@@ -2,12 +2,12 @@ use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
 use crate::build_helper::{BuildHelper, Profile};
-use crate::charwise::DEAD_STATE_IDX;
 use crate::charwise::{CharwiseDoubleArrayAhoCorasick, CodeMapper, MatchKind, State};
 use crate::errors::{DaachorseError, Result};
 use crate::nfa_builder::NfaBuilder;
 use crate::nfa_builder::DEAD_STATE_ID;
 use crate::utils::FromU32;
+use crate::DEAD_STATE_IDX;
 
 // Specialized [`NfaBuilder`] handling labels of `char`.
 type CharwiseNfaBuilder<V> = NfaBuilder<char, V>;

--- a/src/charwise/builder.rs
+++ b/src/charwise/builder.rs
@@ -18,7 +18,6 @@ pub struct CharwiseDoubleArrayAhoCorasickBuilder {
     mapper: CodeMapper,
     match_kind: MatchKind,
     corpus: Vec<String>,
-    num_free_blocks: u32,
 }
 
 impl Default for CharwiseDoubleArrayAhoCorasickBuilder {
@@ -57,7 +56,6 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
             mapper: CodeMapper::default(),
             match_kind: MatchKind::Standard,
             corpus: vec![],
-            num_free_blocks: 64,
         }
     }
 
@@ -72,29 +70,6 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
         self
     }
 
-    /// Specifies the number of trailing blocks to use when searching for base values.
-    ///
-    /// The smaller the number is, the faster the construction time will be; however, the memory
-    /// efficiency can be degraded.
-    ///
-    /// When a corpus is specified with [`Self::corpus()`], states accessed in scanning the
-    /// corpus are placed by scanning all the blocks regardless of this value, and only the
-    /// remaining states are placed using the trailing blocks.
-    ///
-    /// # Arguments
-    ///
-    /// * `n` - The number of last blocks.
-    ///
-    /// # Panics
-    ///
-    /// `n` must be greater than or equal to 1.
-    #[must_use]
-    pub const fn num_free_blocks(mut self, n: u32) -> Self {
-        assert!(n >= 1);
-        self.num_free_blocks = n;
-        self
-    }
-
     /// Specifies a corpus of sample documents for the profile-guided layout optimization.
     ///
     /// States frequently accessed in scanning the corpus are packed densely at small indices
@@ -102,8 +77,8 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
     /// The corpus never changes match results, only the memory layout of the automaton.
     ///
     /// Since the states accessed in scanning the corpus are placed by scanning all the blocks
-    /// (see [`Self::num_free_blocks()`]), the construction time can increase, especially when
-    /// the corpus covers most states of a large pattern set.
+    /// of the double array, the construction time can increase, especially when the corpus
+    /// covers most states of a large pattern set.
     ///
     /// # Arguments
     ///
@@ -322,13 +297,7 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
     {
         let block_len = self.mapper.block_len();
         let groups = nfa.sibling_groups(profile, |c| self.mapper.get(c).unwrap());
-        let helper = BuildHelper::new(
-            &groups,
-            nfa.states.len(),
-            block_len,
-            self.num_free_blocks,
-            false,
-        )?;
+        let helper = BuildHelper::new(&groups, nfa.states.len(), block_len, false)?;
 
         self.states
             .resize(usize::from_u32(helper.num_elements()), State::default());

--- a/src/charwise/builder.rs
+++ b/src/charwise/builder.rs
@@ -1,14 +1,13 @@
-use core::num::NonZeroU32;
-
+use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
+use crate::build_helper::{BuildHelper, Profile};
+use crate::charwise::DEAD_STATE_IDX;
 use crate::charwise::{CharwiseDoubleArrayAhoCorasick, CodeMapper, MatchKind, State};
-use crate::charwise::{DEAD_STATE_IDX, ROOT_STATE_IDX};
 use crate::errors::{DaachorseError, Result};
 use crate::nfa_builder::NfaBuilder;
 use crate::nfa_builder::{DEAD_STATE_ID, ROOT_STATE_ID};
 use crate::utils::FromU32;
-use crate::BuildHelper;
 
 // Specialized [`NfaBuilder`] handling labels of `char`.
 type CharwiseNfaBuilder<V> = NfaBuilder<char, V>;
@@ -18,7 +17,7 @@ pub struct CharwiseDoubleArrayAhoCorasickBuilder {
     states: Vec<State>,
     mapper: CodeMapper,
     match_kind: MatchKind,
-    block_len: u32,
+    corpus: Vec<String>,
     num_free_blocks: u32,
 }
 
@@ -57,7 +56,7 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
             states: vec![],
             mapper: CodeMapper::default(),
             match_kind: MatchKind::Standard,
-            block_len: 0,
+            corpus: vec![],
             num_free_blocks: 16,
         }
     }
@@ -89,6 +88,46 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
     pub const fn num_free_blocks(mut self, n: u32) -> Self {
         assert!(n >= 1);
         self.num_free_blocks = n;
+        self
+    }
+
+    /// Specifies a corpus of sample documents for the profile-guided layout optimization.
+    ///
+    /// # Arguments
+    ///
+    /// * `haystacks` - Sample documents to be scanned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use daachorse::CharwiseDoubleArrayAhoCorasickBuilder;
+    ///
+    /// let patterns = vec!["全世界", "世界", "に"];
+    /// let pma = CharwiseDoubleArrayAhoCorasickBuilder::new()
+    ///     .corpus(["全世界中に"])
+    ///     .build(patterns)
+    ///     .unwrap();
+    ///
+    /// let mut it = pma.find_iter("全世界中に");
+    ///
+    /// let m = it.next().unwrap();
+    /// assert_eq!((0, 9, 0), (m.start(), m.end(), m.value()));
+    ///
+    /// let m = it.next().unwrap();
+    /// assert_eq!((12, 15, 2), (m.start(), m.end(), m.value()));
+    ///
+    /// assert_eq!(None, it.next());
+    /// ```
+    #[must_use]
+    pub fn corpus<I, P>(mut self, haystacks: I) -> Self
+    where
+        I: IntoIterator<Item = P>,
+        P: AsRef<str>,
+    {
+        self.corpus = haystacks
+            .into_iter()
+            .map(|h| h.as_ref().to_string())
+            .collect();
         self
     }
 
@@ -186,7 +225,12 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
     {
         let nfa = self.build_original_nfa_and_mapper(patvals)?;
 
-        self.build_double_array(&nfa)?;
+        let profile = if self.corpus.is_empty() {
+            Profile::new(nfa.states.len())
+        } else {
+            self.profile_corpus(&nfa)
+        };
+        self.build_double_array(&nfa, &profile)?;
 
         // -1 is for dead state
         let num_states = u32::try_from(nfa.states.len() - 1)
@@ -238,49 +282,61 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
         Ok(nfa)
     }
 
-    fn build_double_array<V>(&mut self, nfa: &CharwiseNfaBuilder<V>) -> Result<()> {
-        let mut helper = self.init_array()?;
-
-        let mut state_id_map = vec![DEAD_STATE_IDX; nfa.states.len()];
-        state_id_map[usize::from_u32(ROOT_STATE_ID)] = ROOT_STATE_IDX;
-
-        // Arranges base & check values
-        let mut stack = vec![ROOT_STATE_ID];
-        let mut mapped = vec![];
-
-        while let Some(state_id) = stack.pop() {
-            debug_assert_ne!(state_id, DEAD_STATE_ID);
-            let s = &nfa.states[usize::from_u32(state_id)];
-
-            let state_idx = state_id_map[usize::from_u32(state_id)];
-            debug_assert_ne!(state_idx, DEAD_STATE_IDX);
-
-            if s.edges.is_empty() {
-                continue;
+    fn profile_corpus<V>(&self, nfa: &CharwiseNfaBuilder<V>) -> Profile
+    where
+        V: Copy,
+    {
+        let mut profile = Profile::new(nfa.states.len());
+        for haystack in &self.corpus {
+            let mut state_id = ROOT_STATE_ID;
+            for c in haystack.chars() {
+                if self.mapper.get(c).is_none() {
+                    state_id = ROOT_STATE_ID;
+                    continue;
+                }
+                state_id = nfa.profile_step(state_id, c, &mut profile, false);
             }
+        }
+        profile
+    }
 
-            mapped.clear();
-            for &(label, child_id) in s.edges.iter() {
-                mapped.push((self.mapper.get(label).unwrap(), child_id));
-            }
-            mapped.sort_unstable_by_key(|x| x.0);
+    fn build_double_array<V>(
+        &mut self,
+        nfa: &CharwiseNfaBuilder<V>,
+        profile: &Profile,
+    ) -> Result<()>
+    where
+        V: Copy,
+    {
+        let block_len = self.mapper.block_len();
+        let groups = nfa.sibling_groups(profile, |c| self.mapper.get(c).unwrap());
+        let helper = BuildHelper::new(
+            &groups,
+            nfa.states.len(),
+            block_len,
+            self.num_free_blocks,
+            false,
+        )?;
 
-            let base = self.find_base(&mapped, &helper);
-            if self.states.len() <= usize::from_u32(base.get()) {
-                self.extend_array(&mut helper)?;
+        self.states
+            .resize(usize::from_u32(helper.num_elements()), State::default());
+        for group in &groups {
+            let parent_idx = helper.idx_map[usize::from_u32(group.parent)];
+            for &(_, child_id) in &group.children {
+                self.states[usize::from_u32(helper.idx_map[usize::from_u32(child_id)])]
+                    .set_check(parent_idx);
             }
-
-            for &(c, child_id) in &mapped {
-                let child_idx = base.get() ^ c;
-                helper.use_index(child_idx);
-                self.states[usize::from_u32(child_idx)].set_check(state_idx);
-                state_id_map[usize::from_u32(child_id)] = child_idx;
-                stack.push(child_id);
-            }
-            self.states[usize::from_u32(state_idx)].set_base(base);
+            // BuildHelper::new() assigns a BASE value to every group.
+            self.states[usize::from_u32(parent_idx)]
+                .set_base(helper.bases[usize::from_u32(group.parent)].unwrap());
         }
 
-        // Sets fail & output_pos values
+        self.set_fails_and_outputs(nfa, &helper.idx_map);
+
+        Ok(())
+    }
+
+    fn set_fails_and_outputs<V>(&mut self, nfa: &CharwiseNfaBuilder<V>, state_id_map: &[u32]) {
         for (i, s) in nfa.states.iter().enumerate() {
             if i == usize::from_u32(DEAD_STATE_ID) {
                 continue;
@@ -300,61 +356,5 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
                 self.states[idx].set_fail(fail_idx);
             }
         }
-
-        self.states.shrink_to_fit();
-        Ok(())
-    }
-
-    fn init_array(&mut self) -> Result<BuildHelper> {
-        self.block_len = self.mapper.alphabet_size().next_power_of_two().max(2);
-        self.states
-            .resize(usize::from_u32(self.block_len), State::default());
-        let mut helper = BuildHelper::new(self.block_len, self.num_free_blocks)?;
-        helper.push_block().unwrap();
-        helper.use_index(ROOT_STATE_IDX);
-        helper.use_index(DEAD_STATE_IDX);
-        Ok(helper)
-    }
-
-    #[inline(always)]
-    fn find_base(&self, edges: &[(u32, u32)], helper: &BuildHelper) -> NonZeroU32 {
-        debug_assert!(!edges.is_empty());
-
-        for idx in helper.vacant_iter() {
-            let base = idx ^ edges[0].0;
-            if let Some(base) = Self::verify_base(base, edges, helper) {
-                return base;
-            }
-        }
-        // len() is not 0 since states has at least block_len items.
-        // The following value is always larger than or equal to len() since block_len is
-        // alphabet_size().next_power_of_two().
-        NonZeroU32::new(u32::try_from(self.states.len()).unwrap() ^ edges[0].0).unwrap()
-    }
-
-    #[inline(always)]
-    fn verify_base(base: u32, edges: &[(u32, u32)], helper: &BuildHelper) -> Option<NonZeroU32> {
-        for &(c, _) in edges {
-            let idx = base ^ c;
-            if helper.is_used_index(idx) {
-                return None;
-            }
-        }
-        NonZeroU32::new(base)
-    }
-
-    #[inline(always)]
-    fn extend_array(&mut self, helper: &mut BuildHelper) -> Result<()> {
-        if self.states.len() > usize::from_u32(u32::MAX - self.block_len) {
-            return Err(DaachorseError::automaton_scale("states.len()", u32::MAX));
-        }
-
-        helper.push_block()?;
-        self.states.resize(
-            self.states.len() + usize::from_u32(self.block_len),
-            State::default(),
-        );
-
-        Ok(())
     }
 }

--- a/src/charwise/builder.rs
+++ b/src/charwise/builder.rs
@@ -213,7 +213,7 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
         let nfa = self.build_original_nfa_and_mapper(patvals)?;
 
         let profile = if self.corpus.is_empty() {
-            Profile::new(nfa.states.len())
+            Profile::default()
         } else {
             self.profile_corpus(&nfa)
         };
@@ -273,7 +273,8 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
     where
         V: Copy,
     {
-        let mut profile = Profile::new(nfa.states.len());
+        let mut profile = Profile::default();
+        profile.resize(nfa.states.len());
         let mut chars = vec![];
         for haystack in &self.corpus {
             chars.clear();

--- a/src/charwise/builder.rs
+++ b/src/charwise/builder.rs
@@ -6,7 +6,7 @@ use crate::charwise::DEAD_STATE_IDX;
 use crate::charwise::{CharwiseDoubleArrayAhoCorasick, CodeMapper, MatchKind, State};
 use crate::errors::{DaachorseError, Result};
 use crate::nfa_builder::NfaBuilder;
-use crate::nfa_builder::{DEAD_STATE_ID, ROOT_STATE_ID};
+use crate::nfa_builder::DEAD_STATE_ID;
 use crate::utils::FromU32;
 
 // Specialized [`NfaBuilder`] handling labels of `char`.
@@ -57,7 +57,7 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
             mapper: CodeMapper::default(),
             match_kind: MatchKind::Standard,
             corpus: vec![],
-            num_free_blocks: 16,
+            num_free_blocks: 64,
         }
     }
 
@@ -77,6 +77,10 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
     /// The smaller the number is, the faster the construction time will be; however, the memory
     /// efficiency can be degraded.
     ///
+    /// When a corpus is specified with [`Self::corpus()`], states accessed in scanning the
+    /// corpus are placed by scanning all the blocks regardless of this value, and only the
+    /// remaining states are placed using the trailing blocks.
+    ///
     /// # Arguments
     ///
     /// * `n` - The number of last blocks.
@@ -92,6 +96,14 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
     }
 
     /// Specifies a corpus of sample documents for the profile-guided layout optimization.
+    ///
+    /// States frequently accessed in scanning the corpus are packed densely at small indices
+    /// so that matching on documents similar to the corpus becomes more cache-efficient.
+    /// The corpus never changes match results, only the memory layout of the automaton.
+    ///
+    /// Since the states accessed in scanning the corpus are placed by scanning all the blocks
+    /// (see [`Self::num_free_blocks()`]), the construction time can increase, especially when
+    /// the corpus covers most states of a large pattern set.
     ///
     /// # Arguments
     ///
@@ -287,15 +299,15 @@ impl CharwiseDoubleArrayAhoCorasickBuilder {
         V: Copy,
     {
         let mut profile = Profile::new(nfa.states.len());
+        let mut chars = vec![];
         for haystack in &self.corpus {
-            let mut state_id = ROOT_STATE_ID;
-            for c in haystack.chars() {
-                if self.mapper.get(c).is_none() {
-                    state_id = ROOT_STATE_ID;
-                    continue;
-                }
-                state_id = nfa.profile_step(state_id, c, &mut profile, false);
-            }
+            chars.clear();
+            chars.extend(haystack.chars());
+            // The character-wise version has no dense root table, and characters not in the
+            // mapper reset the state to the root without accessing the double array.
+            nfa.profile_haystack(&chars, &mut profile, false, |c| {
+                self.mapper.get(c).is_some()
+            });
         }
         profile
     }

--- a/src/charwise/iter.rs
+++ b/src/charwise/iter.rs
@@ -4,9 +4,8 @@ use core::iter::Enumerate;
 use core::num::NonZeroU32;
 
 use crate::charwise::CharwiseDoubleArrayAhoCorasick;
-use crate::charwise::ROOT_STATE_IDX;
 use crate::utils::FromU32;
-use crate::Match;
+use crate::{Match, ROOT_STATE_IDX};
 
 /// Iterator for some struct that implements [`AsRef<str>`].
 #[doc(hidden)]

--- a/src/charwise/mapper.rs
+++ b/src/charwise/mapper.rs
@@ -46,6 +46,11 @@ impl CodeMapper {
         self.alphabet_size
     }
 
+    #[inline(always)]
+    pub fn block_len(&self) -> u32 {
+        self.alphabet_size.next_power_of_two().max(2)
+    }
+
     #[inline]
     #[allow(dead_code)]
     pub fn heap_bytes(&self) -> usize {

--- a/src/edge_map.rs
+++ b/src/edge_map.rs
@@ -58,10 +58,6 @@ where
         matches!(self, Self::Empty)
     }
 
-    pub fn keys(&self) -> impl Iterator<Item = &L> {
-        self.iter().map(|(k, _)| k)
-    }
-
     pub fn values(&self) -> impl Iterator<Item = &u32> {
         self.iter().map(|(_, v)| v)
     }

--- a/src/edge_map.rs
+++ b/src/edge_map.rs
@@ -69,4 +69,12 @@ where
             Self::Many(entries) => entries.iter(),
         }
     }
+
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Empty => 0,
+            Self::One(_) => 1,
+            Self::Many(entries) => entries.len(),
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,12 +203,16 @@ use core::num::NonZeroU32;
 
 use alloc::vec::Vec;
 
-use crate::build_helper::BuildHelper;
 pub use crate::bytewise::{DoubleArrayAhoCorasick, DoubleArrayAhoCorasickBuilder};
 pub use crate::charwise::{CharwiseDoubleArrayAhoCorasick, CharwiseDoubleArrayAhoCorasickBuilder};
 use crate::errors::DaachorseError;
 pub use crate::errors::Result;
 pub use crate::serializer::Serializable;
+
+// The root index position.
+pub(crate) const ROOT_STATE_IDX: u32 = 0;
+// The dead index position.
+pub(crate) const DEAD_STATE_IDX: u32 = 1;
 
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 struct Output<V> {

--- a/src/nfa_builder.rs
+++ b/src/nfa_builder.rs
@@ -1,8 +1,10 @@
 use core::cell::Cell;
+use core::cmp::Reverse;
 use core::num::NonZeroU32;
 
 use alloc::vec::Vec;
 
+use crate::build_helper::{Profile, SiblingGroup};
 use crate::edge_map::EdgeMap;
 use crate::errors::{DaachorseError, Result};
 use crate::utils::FromU32;
@@ -227,5 +229,68 @@ where
             .edges
             .get(&c)
             .copied()
+    }
+
+    pub(crate) fn profile_step(
+        &self,
+        mut state_id: u32,
+        c: L,
+        profile: &mut Profile,
+        dense_root: bool,
+    ) -> u32 {
+        loop {
+            if dense_root && state_id == ROOT_STATE_ID {
+                state_id = self.child_id(ROOT_STATE_ID, c).unwrap_or(ROOT_STATE_ID);
+                break;
+            }
+            let s = &self.states[usize::from_u32(state_id)];
+            profile.visits[usize::from_u32(state_id)] += 1;
+            if !s.edges.is_empty() {
+                if let Some(child_id) = s.edges.get(&c) {
+                    state_id = *child_id;
+                    break;
+                }
+                profile.probes[usize::from_u32(state_id)] += 1;
+            }
+            if state_id == ROOT_STATE_ID {
+                break;
+            }
+            let fail_id = s.fail.get();
+            if fail_id == DEAD_STATE_ID {
+                state_id = ROOT_STATE_ID;
+                break;
+            }
+            state_id = fail_id;
+        }
+        profile.visits[usize::from_u32(state_id)] += 1;
+        state_id
+    }
+
+    pub(crate) fn sibling_groups<M>(&self, profile: &Profile, mut map_label: M) -> Vec<SiblingGroup>
+    where
+        M: FnMut(L) -> u32,
+    {
+        let mut groups = vec![];
+        let mut stack = vec![ROOT_STATE_ID];
+        while let Some(state_id) = stack.pop() {
+            let s = &self.states[usize::from_u32(state_id)];
+            if s.edges.is_empty() {
+                continue;
+            }
+            let mut children = Vec::with_capacity(1);
+            let mut weight = profile.probes[usize::from_u32(state_id)];
+            for &(c, child_id) in s.edges.iter() {
+                weight += profile.visits[usize::from_u32(child_id)];
+                children.push((map_label(c), child_id));
+                stack.push(child_id);
+            }
+            groups.push(SiblingGroup {
+                parent: state_id,
+                children,
+                weight,
+            });
+        }
+        groups.sort_by_key(|g| Reverse(g.weight));
+        groups
     }
 }

--- a/src/nfa_builder.rs
+++ b/src/nfa_builder.rs
@@ -314,15 +314,22 @@ where
     {
         let mut groups = vec![];
         let mut stack = vec![ROOT_STATE_ID];
+        let profiled = !profile.is_empty();
         while let Some(state_id) = stack.pop() {
             let s = &self.states[usize::from_u32(state_id)];
             if s.edges.is_empty() {
                 continue;
             }
             let mut children = Vec::with_capacity(s.edges.len());
-            let mut weight = profile.probes[usize::from_u32(state_id)];
+            let mut weight = if profiled {
+                profile.probes[usize::from_u32(state_id)]
+            } else {
+                0
+            };
             for &(c, child_id) in s.edges.iter() {
-                weight += profile.visits[usize::from_u32(child_id)];
+                if profiled {
+                    weight += profile.visits[usize::from_u32(child_id)];
+                }
                 children.push((map_label(c), child_id));
                 stack.push(child_id);
             }
@@ -332,10 +339,12 @@ where
                 weight,
             });
         }
-        // The sort must be stable so that groups with equal weights (in particular, all the
-        // groups when no corpus is given) keep the depth-first order and are placed in the
-        // same order as the classic depth-first construction.
-        groups.sort_by_key(|g| Reverse(g.weight));
+        // With no profile, the sort is skipped and the groups keep the depth-first order, in
+        // which they are placed in the same order as the classic depth-first construction.
+        // The sort must be stable so that groups with equal weights also keep that order.
+        if profiled {
+            groups.sort_by_key(|g| Reverse(g.weight));
+        }
         groups
     }
 }

--- a/src/nfa_builder.rs
+++ b/src/nfa_builder.rs
@@ -319,7 +319,7 @@ where
             if s.edges.is_empty() {
                 continue;
             }
-            let mut children = Vec::with_capacity(1);
+            let mut children = Vec::with_capacity(s.edges.len());
             let mut weight = profile.probes[usize::from_u32(state_id)];
             for &(c, child_id) in s.edges.iter() {
                 weight += profile.visits[usize::from_u32(child_id)];

--- a/src/nfa_builder.rs
+++ b/src/nfa_builder.rs
@@ -231,7 +231,7 @@ where
             .copied()
     }
 
-    pub(crate) fn profile_step(
+    fn profile_step(
         &self,
         mut state_id: u32,
         c: L,
@@ -239,31 +239,73 @@ where
         dense_root: bool,
     ) -> u32 {
         loop {
+            // The runtime handles such root transitions with a dense table without accessing
+            // the double array, so no access is counted.
             if dense_root && state_id == ROOT_STATE_ID {
-                state_id = self.child_id(ROOT_STATE_ID, c).unwrap_or(ROOT_STATE_ID);
-                break;
+                return self.child_id(ROOT_STATE_ID, c).unwrap_or(ROOT_STATE_ID);
             }
             let s = &self.states[usize::from_u32(state_id)];
+            // The runtime reads the double-array element of the current state.
             profile.visits[usize::from_u32(state_id)] += 1;
             if !s.edges.is_empty() {
-                if let Some(child_id) = s.edges.get(&c) {
-                    state_id = *child_id;
-                    break;
+                if let Some(&child_id) = s.edges.get(&c) {
+                    // A successful probe reads the element of the child.
+                    profile.visits[usize::from_u32(child_id)] += 1;
+                    return child_id;
                 }
+                // A failed probe reads an element in the block where the children of this
+                // state are placed.
                 profile.probes[usize::from_u32(state_id)] += 1;
             }
             if state_id == ROOT_STATE_ID {
-                break;
+                return ROOT_STATE_ID;
             }
             let fail_id = s.fail.get();
             if fail_id == DEAD_STATE_ID {
-                state_id = ROOT_STATE_ID;
-                break;
+                return ROOT_STATE_ID;
             }
             state_id = fail_id;
         }
-        profile.visits[usize::from_u32(state_id)] += 1;
-        state_id
+    }
+
+    pub(crate) fn profile_haystack<F>(
+        &self,
+        haystack: &[L],
+        profile: &mut Profile,
+        dense_root: bool,
+        mut has_label: F,
+    ) where
+        F: FnMut(L) -> bool,
+    {
+        let leftmost = self.match_kind.is_leftmost();
+        let mut state_id = ROOT_STATE_ID;
+        let mut match_end = None;
+        let mut pos = 0;
+        while pos < haystack.len() {
+            let c = haystack[pos];
+            state_id = if has_label(c) {
+                self.profile_step(state_id, c, profile, dense_root)
+            } else {
+                ROOT_STATE_ID
+            };
+            if leftmost {
+                if state_id == ROOT_STATE_ID {
+                    // The leftmost iterators yield the pending match here and restart
+                    // scanning at its end position in the next call.
+                    if let Some(end) = match_end.take() {
+                        pos = end;
+                        continue;
+                    }
+                } else if self.states[usize::from_u32(state_id)]
+                    .output_pos
+                    .get()
+                    .is_some()
+                {
+                    match_end = Some(pos + 1);
+                }
+            }
+            pos += 1;
+        }
     }
 
     pub(crate) fn sibling_groups<M>(&self, profile: &Profile, mut map_label: M) -> Vec<SiblingGroup>
@@ -290,6 +332,9 @@ where
                 weight,
             });
         }
+        // The sort must be stable so that groups with equal weights (in particular, all the
+        // groups when no corpus is given) keep the depth-first order and are placed in the
+        // same order as the classic depth-first construction.
         groups.sort_by_key(|g| Reverse(g.weight));
         groups
     }

--- a/tests/corpus_test.rs
+++ b/tests/corpus_test.rs
@@ -1,0 +1,99 @@
+use daachorse::{
+    CharwiseDoubleArrayAhoCorasick, CharwiseDoubleArrayAhoCorasickBuilder, DoubleArrayAhoCorasick,
+    DoubleArrayAhoCorasickBuilder, MatchKind,
+};
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
+
+fn random_string(rng: &mut SmallRng, alphabet: &[char], max_len: usize) -> String {
+    let len = rng.random_range(1..=max_len);
+    (0..len)
+        .map(|_| alphabet[rng.random_range(0..alphabet.len())])
+        .collect()
+}
+
+macro_rules! corpus_test {
+    ($name:ident, $builder:ident, $pma:ty, $kind:expr, $find:ident) => {
+        #[test]
+        fn $name() {
+            let alphabet: Vec<char> = "abc火星猫".chars().collect();
+            for trial in 0..100 {
+                let trial_seed: u64 = rand::random();
+                let mut rng = SmallRng::seed_from_u64(trial_seed);
+                let mut patterns: Vec<String> = (0..20)
+                    .map(|_| random_string(&mut rng, &alphabet, 6))
+                    .collect();
+                patterns.sort();
+                patterns.dedup();
+                let corpus: Vec<String> = (0..5)
+                    .map(|_| random_string(&mut rng, &alphabet, 200))
+                    .collect();
+                let haystack = random_string(&mut rng, &alphabet, 300);
+
+                let plain: $pma = $builder::new().match_kind($kind).build(&patterns).unwrap();
+                let tuned: $pma = $builder::new()
+                    .match_kind($kind)
+                    .corpus(&corpus)
+                    .build(&patterns)
+                    .unwrap();
+                let expected: Vec<_> = plain
+                    .$find(&haystack)
+                    .map(|m| (m.start(), m.end(), m.value()))
+                    .collect();
+                let actual: Vec<_> = tuned
+                    .$find(&haystack)
+                    .map(|m| (m.start(), m.end(), m.value()))
+                    .collect();
+                assert_eq!(expected, actual, "trial {trial}, seed 0x{trial_seed:016x}");
+            }
+        }
+    };
+}
+
+corpus_test!(
+    bytewise_standard,
+    DoubleArrayAhoCorasickBuilder,
+    DoubleArrayAhoCorasick<u32>,
+    MatchKind::Standard,
+    find_overlapping_iter
+);
+
+corpus_test!(
+    bytewise_leftmost_longest,
+    DoubleArrayAhoCorasickBuilder,
+    DoubleArrayAhoCorasick<u32>,
+    MatchKind::LeftmostLongest,
+    leftmost_find_iter
+);
+
+corpus_test!(
+    bytewise_leftmost_first,
+    DoubleArrayAhoCorasickBuilder,
+    DoubleArrayAhoCorasick<u32>,
+    MatchKind::LeftmostFirst,
+    leftmost_find_iter
+);
+
+corpus_test!(
+    charwise_standard,
+    CharwiseDoubleArrayAhoCorasickBuilder,
+    CharwiseDoubleArrayAhoCorasick<u32>,
+    MatchKind::Standard,
+    find_overlapping_iter
+);
+
+corpus_test!(
+    charwise_leftmost_longest,
+    CharwiseDoubleArrayAhoCorasickBuilder,
+    CharwiseDoubleArrayAhoCorasick<u32>,
+    MatchKind::LeftmostLongest,
+    leftmost_find_iter
+);
+
+corpus_test!(
+    charwise_leftmost_first,
+    CharwiseDoubleArrayAhoCorasickBuilder,
+    CharwiseDoubleArrayAhoCorasick<u32>,
+    MatchKind::LeftmostFirst,
+    leftmost_find_iter
+);

--- a/tests/invalid_option_test.rs
+++ b/tests/invalid_option_test.rs
@@ -1,9 +1,0 @@
-use daachorse::{DoubleArrayAhoCorasick, DoubleArrayAhoCorasickBuilder};
-
-#[test]
-fn test_large_num_free_blocks() {
-    let pma: Result<DoubleArrayAhoCorasick<usize>, _> = DoubleArrayAhoCorasickBuilder::new()
-        .num_free_blocks(u32::MAX)
-        .build(["pattern"]);
-    assert!(pma.is_err());
-}


### PR DESCRIPTION
This branch implements a feature that enables profile-guided layout optimization (PGLO) when constructing a double array.

By supplying sample documents via a new builder option (`corpus()`), states that are frequently accessed during matching are packed densely at small indices of the double array, improving cache locality when scanning documents similar to the samples.

`BuildHelper` no longer keeps vacancy information in a fixed-size ring buffer covering only the trailing blocks. It now tracks the whole array, and slots that fall out of the window are merely unlinked from the scan list rather than marked as used. This is what allows the exhaustive packing phase to place hot groups anywhere in the array, and it also lets the CHECK-fixing pass for vacant slots run once at the end of construction instead of every time a block is dropped from the ring. The construction-time footprint of the helper grows from O(window) to O(array length).

Using UniDic and the 13 subsets of the BCCWJ, I performed training and string search across each pairwise combination of subsets and measured the reduction in time relative to the case without optimization.
Overall, the reduction rate is larger when the domains match, but the optimization was confirmed to be effective even across different domains.

## Bytewise

<img width="1077" height="907" alt="bytewise" src="https://github.com/user-attachments/assets/3630b145-5681-48e7-9534-168606b8575d" />

## Charwise
<img width="1077" height="907" alt="charwise" src="https://github.com/user-attachments/assets/f76addad-4735-44cd-89e5-3feadefb9478" />
