### PR TITLE
Add main algorithm of Shift-Or with q-Grams prefilter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,6 +196,7 @@ mod edge_map;
 pub mod errors;
 mod intpack;
 mod nfa_builder;
+mod prefilter;
 mod serializer;
 mod utils;
 

--- a/src/prefilter.rs
+++ b/src/prefilter.rs
@@ -64,6 +64,9 @@ impl Prefilter {
         for (i, &c) in haystack.iter().enumerate().skip(pos + 1) {
             e = (e << 1) | self.table[usize::from(prev) << 8 | usize::from(c)];
             if e & self.hit_bit == 0 {
+                // Starting from an all-one state, the hit bit cannot become zero until
+                // `window_len - 1` 2-grams have been consumed, so this subtraction cannot
+                // underflow.
                 return i + 1 - usize::from(self.window_len);
             }
             prev = c;

--- a/src/prefilter.rs
+++ b/src/prefilter.rs
@@ -52,16 +52,16 @@ impl Prefilter {
     /// time.
     const MAX_EXPECTED_CANDIDATE_RATE: f64 = 1. / 16.;
 
-    /// Returns the smallest position `>= start` where an occurrence of some pattern can start, or
+    /// Returns the smallest position `>= pos` where an occurrence of some pattern can start, or
     /// `haystack.len()` if there is none. The result may be a false positive, but there is never
-    /// an occurrence starting in `start..result`.
+    /// an occurrence starting in `pos..result`.
     #[inline(always)]
-    pub fn next_position(&self, haystack: &[u8], start: usize) -> usize {
-        let Some(&(mut prev)) = haystack.get(start) else {
+    pub fn next_position(&self, haystack: &[u8], pos: usize) -> usize {
+        let Some(&(mut prev)) = haystack.get(pos) else {
             return haystack.len();
         };
         let mut e = u8::MAX;
-        for (i, &c) in haystack.iter().enumerate().skip(start + 1) {
+        for (i, &c) in haystack.iter().enumerate().skip(pos + 1) {
             e = (e << 1) | self.table[usize::from(prev) << 8 | usize::from(c)];
             if e & self.hit_bit == 0 {
                 return i + 1 - usize::from(self.window_len);
@@ -75,14 +75,13 @@ impl Prefilter {
     /// UTF-8 character. Candidates starting with a continuation byte cannot be occurrences of
     /// character-wise patterns, so they are simply skipped.
     #[inline(always)]
-    pub fn next_position_at_char_boundary(&self, haystack: &[u8], start: usize) -> usize {
-        let mut pos = start;
+    pub fn next_position_at_char_boundary(&self, haystack: &[u8], mut pos: usize) -> usize {
         loop {
             let candidate_pos = self.next_position(haystack, pos);
-            let Some(&first) = haystack.get(candidate_pos) else {
+            let Some(&c) = haystack.get(candidate_pos) else {
                 return haystack.len();
             };
-            if first & 0xc0 != 0x80 {
+            if c & 0xc0 != 0x80 {
                 return candidate_pos;
             }
             pos = candidate_pos + 1;
@@ -241,9 +240,7 @@ mod tests {
 
     fn build(patterns: &[&[u8]]) -> Option<Prefilter> {
         let mut builder = PrefilterBuilder::new();
-        for pattern in patterns {
-            builder.add(pattern);
-        }
+        patterns.iter().for_each(|pattern| builder.add(pattern));
         builder.build()
     }
 
@@ -263,11 +260,7 @@ mod tests {
         // All 2-byte patterns clear every table entry at position 0, making the expected
         // candidate rate 1.
         let mut builder = PrefilterBuilder::new();
-        for a in 0..=255u8 {
-            for b in 0..=255u8 {
-                builder.add(&[a, b]);
-            }
-        }
+        (0..=u16::MAX).for_each(|gram| builder.add(&gram.to_be_bytes()));
         assert!(builder.build().is_none());
     }
 
@@ -276,66 +269,63 @@ mod tests {
         // Patterns longer than MAX_WINDOW_LEN must not overflow the 8-bit table entries.
         let long = b"undine".repeat(20);
         let pf = build(&[&long, b"neovenezia"]).unwrap();
-        let mut haystack = vec![b'x'; 50];
-        haystack.extend_from_slice(&long);
+        let haystack = [&[b'x'; 50][..], &long].concat();
         assert_eq!(pf.next_position(&haystack, 0), 50);
     }
 
     #[test]
-    fn test_next_position_never_skips_occurrences() {
-        let patterns: &[&[u8]] = &[b"aria", b"rari", b"iaria", b"ariaariaaria"];
-        let pf = build(patterns).unwrap();
-        // A real occurrence must never lie before the returned position.
-        assert!(pf.next_position(b"iiiiariaii", 0) <= 4);
-        // Exhaustively check all haystacks over {a, r, i} up to length 8: walking a haystack
-        // candidate by candidate, no occurrence may start in a skipped section. Real
-        // occurrences are thus never passed over, since a candidate section is skipped only
-        // after being checked here.
-        for len in 0..=8u32 {
-            for haystack_code in 0..3usize.pow(len) {
-                let mut code = haystack_code;
-                let haystack: Vec<u8> = (0..len)
-                    .map(|_| {
-                        let c = b"ari"[code % 3];
-                        code /= 3;
-                        c
-                    })
-                    .collect();
-                let mut pos = 0;
-                while pos < haystack.len() {
-                    let candidate = pf.next_position(&haystack, pos);
-                    for start in pos..candidate {
-                        for pattern in patterns {
-                            assert_ne!(haystack.get(start..start + pattern.len()), Some(*pattern));
-                        }
-                    }
-                    pos = candidate + 1;
-                }
-                assert_eq!(pf.next_position(&haystack, haystack.len()), haystack.len());
-            }
-        }
+    fn test_next_position_reports_occurrence() {
+        let pf = build(&[b"aria", b"iris"]).unwrap();
+        // The candidate is exactly the occurrence of "aria".
+        assert_eq!(pf.next_position(b"xxxxariaxx", 0), 4);
+        // Resuming after the candidate reaches the end without further candidates.
+        assert_eq!(pf.next_position(b"xxxxariaxx", 5), 10);
+        // Starting at the haystack end is allowed.
+        assert_eq!(pf.next_position(b"xxxxariaxx", 10), 10);
     }
 
     #[test]
-    fn test_char_boundary_candidates() {
-        let patterns: &[&[u8]] = &["火星猫".as_bytes(), b"undine"];
-        let pf = build(patterns).unwrap();
-        let haystack = "アリア社長は火星猫で、灯里はundineの見習いです".as_bytes();
-        let mut pos = 0;
-        while pos < haystack.len() {
-            let candidate = pf.next_position_at_char_boundary(haystack, pos);
-            if candidate == haystack.len() {
-                break;
-            }
-            // Candidates are always on a character boundary.
-            assert_ne!(haystack[candidate] & 0xc0, 0x80);
-            for start in pos..candidate {
-                for pattern in patterns {
-                    assert_ne!(haystack.get(start..start + pattern.len()), Some(*pattern));
-                }
-            }
-            pos = candidate + 1;
-        }
+    fn test_next_position_without_occurrence() {
+        let pf = build(&[b"aria", b"iris"]).unwrap();
+        assert_eq!(pf.next_position(b"xxxxxxxxxx", 0), 10);
+        // 2-grams of the patterns appearing at wrong window positions do not form a candidate.
+        assert_eq!(pf.next_position(b"xxarxrixia", 0), 10);
+    }
+
+    #[test]
+    fn test_next_position_may_report_false_positive() {
+        let pf = build(&[b"aria", b"iris"]).unwrap();
+        // "aris" chains 2-grams of both patterns ("ar" and "ri" from "aria", "is" from "iris")
+        // at consistent window positions, so it is reported as a candidate although no pattern
+        // occurs there. The caller verifies candidates on the automaton, so false positives are
+        // harmless.
+        assert_eq!(pf.next_position(b"xxarisxxxx", 0), 2);
+    }
+
+    #[test]
+    fn test_char_boundary_reports_occurrence() {
+        let pf = build(&["火星猫".as_bytes(), b"undine"]).unwrap();
+        let haystack = "アリア社長は火星猫です".as_bytes();
+        // "火星猫" occurs at byte position 18, which is a character boundary.
+        assert_eq!(pf.next_position_at_char_boundary(haystack, 0), 18);
+        assert_eq!(
+            pf.next_position_at_char_boundary(haystack, 19),
+            haystack.len()
+        );
+    }
+
+    #[test]
+    fn test_char_boundary_skips_mid_char_candidates() {
+        // This pattern occurs in "星猫" only at byte position 1, in the middle of a character.
+        let pf = build(&[b"\x98\x9f\xe7\x8c\xab"]).unwrap();
+        let haystack = "星猫".as_bytes();
+        assert_eq!(pf.next_position(haystack, 0), 1);
+        // A mid-character candidate cannot be an occurrence of a character-wise pattern and is
+        // skipped.
+        assert_eq!(
+            pf.next_position_at_char_boundary(haystack, 0),
+            haystack.len()
+        );
     }
 
     #[test]
@@ -356,11 +346,11 @@ mod tests {
         let mut data = vec![];
         pf.serialize_to_vec(&mut data);
         // The window length must stay within its valid range.
-        for bad_window_len in [0, 1, 10, u8::MAX] {
-            let mut data = data.clone();
-            data[0] = bad_window_len;
-            assert!(Prefilter::deserialize_from_slice(&data).is_err());
-        }
+        let with_window_len = |window_len: u8| [&[window_len], &data[1..]].concat();
+        assert!(Prefilter::deserialize_from_slice(&with_window_len(0)).is_err());
+        assert!(Prefilter::deserialize_from_slice(&with_window_len(1)).is_err());
+        assert!(Prefilter::deserialize_from_slice(&with_window_len(10)).is_err());
+        assert!(Prefilter::deserialize_from_slice(&with_window_len(u8::MAX)).is_err());
         // A truncated table must also be rejected.
         assert!(Prefilter::deserialize_from_slice(&data[..data.len() - 1]).is_err());
     }

--- a/src/prefilter.rs
+++ b/src/prefilter.rs
@@ -32,6 +32,7 @@ pub struct Prefilter {
     hit_bit: u8,
 }
 
+#[allow(dead_code)]
 impl Prefilter {
     /// The maximum window length: an 8-bit state supports up to `8 + 2 - 1` bytes because a window of
     /// `m` bytes yields `m - 1` overlapping 2-grams.
@@ -120,6 +121,7 @@ pub struct PrefilterBuilder {
     min_len: usize,
 }
 
+#[allow(dead_code)]
 impl PrefilterBuilder {
     pub fn new() -> Self {
         Self {
@@ -196,6 +198,7 @@ pub struct PrefilterGate {
     enabled: bool,
 }
 
+#[allow(dead_code)]
 impl PrefilterGate {
     /// The number of filter runs in one measurement window of [`PrefilterGate`].
     const GATE_WINDOW_CALLS: u32 = 64;

--- a/src/prefilter.rs
+++ b/src/prefilter.rs
@@ -1,0 +1,364 @@
+//! A match-candidate prefilter based on the SOG (Shift-Or with q-Grams) algorithm.
+//!
+//! The filter scans the haystack with a bit-parallel shift-or automaton over overlapping 2-grams
+//! and reports positions where an occurrence of some pattern can start. Sections between
+//! candidates are guaranteed to contain no occurrence, so the Aho-Corasick automaton can skip
+//! them entirely while it stays in the root state. Candidates may be false positives; they are
+//! simply verified by running the Aho-Corasick automaton as usual, so the filter never changes
+//! match results.
+//!
+//! The algorithm is described in the following paper:
+//!
+//! > Leena Salmela, Jorma Tarhio, and Jari Kytöjoki.
+//! > [Multipattern string matching with q-grams](https://doi.org/10.1145/1187436.1187438).
+//! > *ACM Journal of Experimental Algorithmics*, 11, 2006.
+
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+
+use crate::errors::{DaachorseError, Result};
+use crate::serializer::{Serializable, SerializableVec};
+
+/// A SOG (Shift-Or with 2-Grams) prefilter.
+#[derive(Clone, Eq, Hash, PartialEq)]
+pub struct Prefilter {
+    /// Maps a 2-gram to a bit vector whose `i`-th bit is 0 iff the 2-gram occurs at position `i`
+    /// in the length-`window_len` prefix of some pattern.
+    table: Box<[u8; Self::TABLE_LEN]>,
+    /// The window length `m`: the length of the shortest pattern, capped at
+    /// [`Prefilter::MAX_WINDOW_LEN`].
+    window_len: u8,
+    /// The bit at which a candidate is detected: `1 << (window_len - 2)`.
+    hit_bit: u8,
+}
+
+impl Prefilter {
+    /// The maximum window length: an 8-bit state supports up to `8 + 2 - 1` bytes because a window of
+    /// `m` bytes yields `m - 1` overlapping 2-grams.
+    pub const MAX_WINDOW_LEN: usize = 9;
+
+    /// The minimum window length: a window must contain at least one 2-gram.
+    pub const MIN_WINDOW_LEN: usize = 2;
+
+    /// The number of 2-gram entries in the filter table.
+    const TABLE_LEN: usize = 65536;
+
+    /// The maximum estimated probability that a uniformly random position becomes a candidate.
+    /// A table saturated with the 2-grams of too many patterns reports candidates almost
+    /// everywhere and can hardly skip anything, so such a filter is not built. The estimate
+    /// assumes random text and is thus optimistic on natural-language text; filters passing
+    /// this check but not paying off in practice are disabled by [`PrefilterGate`] at run
+    /// time.
+    const MAX_EXPECTED_CANDIDATE_RATE: f64 = 1. / 16.;
+
+    /// Returns the smallest position `>= start` where an occurrence of some pattern can start, or
+    /// `haystack.len()` if there is none. The result may be a false positive, but there is never
+    /// an occurrence starting in `start..result`.
+    #[inline(always)]
+    pub fn next_position(&self, haystack: &[u8], start: usize) -> usize {
+        let Some(&(mut prev)) = haystack.get(start) else {
+            return haystack.len();
+        };
+        let mut e = u8::MAX;
+        for (i, &c) in haystack.iter().enumerate().skip(start + 1) {
+            e = (e << 1) | self.table[usize::from(prev) << 8 | usize::from(c)];
+            if e & self.hit_bit == 0 {
+                return i + 1 - usize::from(self.window_len);
+            }
+            prev = c;
+        }
+        haystack.len()
+    }
+
+    /// Same as [`Prefilter::next_position`], but never returns a position in the middle of a
+    /// UTF-8 character. Candidates starting with a continuation byte cannot be occurrences of
+    /// character-wise patterns, so they are simply skipped.
+    #[inline(always)]
+    pub fn next_position_at_char_boundary(&self, haystack: &[u8], start: usize) -> usize {
+        let mut pos = start;
+        loop {
+            let candidate_pos = self.next_position(haystack, pos);
+            let Some(&first) = haystack.get(candidate_pos) else {
+                return haystack.len();
+            };
+            if first & 0xc0 != 0x80 {
+                return candidate_pos;
+            }
+            pos = candidate_pos + 1;
+        }
+    }
+
+    /// Returns the heap size of the filter table in bytes.
+    pub const fn heap_bytes(&self) -> usize {
+        Self::TABLE_LEN
+    }
+
+    /// Estimates the probability that a uniformly random position in a random text becomes a
+    /// candidate, as the product over all 2-gram positions of the fraction of 2-grams accepted
+    /// there.
+    fn expected_candidate_rate(&self) -> f64 {
+        let mut zeros = [0u32; 8];
+        for &bits in self.table.iter() {
+            for (i, n) in zeros.iter_mut().enumerate() {
+                *n += u32::from(bits >> i & 1 == 0);
+            }
+        }
+        let mut rate = 1.;
+        for &n in &zeros[..usize::from(self.window_len - 1)] {
+            rate *= f64::from(n) / Self::TABLE_LEN as f64;
+        }
+        rate
+    }
+}
+
+/// An incremental builder of [`Prefilter`]. The automaton builders feed it while the patterns
+/// stream through them, so that no copy of the pattern set is kept for the filter.
+pub struct PrefilterBuilder {
+    /// The table under construction; see [`Prefilter::table`] for the semantics.
+    table: Vec<u8>,
+    /// The length of the shortest pattern added so far, or `usize::MAX` if none has been added.
+    min_len: usize,
+}
+
+impl PrefilterBuilder {
+    pub fn new() -> Self {
+        Self {
+            table: vec![u8::MAX; Prefilter::TABLE_LEN],
+            min_len: usize::MAX,
+        }
+    }
+
+    /// Registers the 2-grams of the pattern's window, which is the pattern itself capped at
+    /// [`Prefilter::MAX_WINDOW_LEN`] bytes.
+    pub fn add(&mut self, pattern: &[u8]) {
+        self.min_len = self.min_len.min(pattern.len());
+        let window = &pattern[..pattern.len().min(Prefilter::MAX_WINDOW_LEN)];
+        for (i, gram) in window.windows(2).enumerate() {
+            self.table[usize::from(gram[0]) << 8 | usize::from(gram[1])] &= !(1 << i);
+        }
+    }
+
+    /// Builds the prefilter, or returns `None` when prefiltering cannot pay off: no pattern was
+    /// added, some pattern is shorter than [`Prefilter::MIN_WINDOW_LEN`], or the table is too
+    /// dense to filter out enough positions.
+    pub fn build(self) -> Option<Prefilter> {
+        // usize::MAX means that no pattern has been added.
+        if self.min_len < Prefilter::MIN_WINDOW_LEN || self.min_len == usize::MAX {
+            return None;
+        }
+        let window_len = self.min_len.min(Prefilter::MAX_WINDOW_LEN);
+        let prefilter = Prefilter {
+            table: self.table.into_boxed_slice().try_into().unwrap(),
+            window_len: window_len.try_into().unwrap(),
+            hit_bit: 1 << (window_len - 2),
+        };
+        (prefilter.expected_candidate_rate() <= Prefilter::MAX_EXPECTED_CANDIDATE_RATE)
+            .then_some(prefilter)
+    }
+}
+
+impl Serializable for Prefilter {
+    fn serialize_to_vec(&self, dst: &mut Vec<u8>) {
+        self.window_len.serialize_to_vec(dst);
+        self.table.serialize_to_vec(dst);
+    }
+
+    fn deserialize_from_slice(src: &[u8]) -> Result<(Self, &[u8])> {
+        let (window_len, src) = u8::deserialize_from_slice(src)?;
+        if !(Self::MIN_WINDOW_LEN..=Self::MAX_WINDOW_LEN).contains(&usize::from(window_len)) {
+            return Err(DaachorseError::invalid_automaton());
+        }
+        let (table, rest) = Box::<[u8; Self::TABLE_LEN]>::deserialize_from_slice(src)?;
+        Ok((
+            Self {
+                table,
+                window_len,
+                hit_bit: 1 << (window_len - 2),
+            },
+            rest,
+        ))
+    }
+
+    fn serialized_bytes() -> usize {
+        u8::serialized_bytes() + Self::TABLE_LEN
+    }
+}
+
+/// A runtime gate that disables prefiltering when it does not pay off on the current haystack.
+///
+/// Each iterator owns a gate. Every filter run records how many bytes it allowed the automaton to
+/// skip, and once the average gain within a measurement window falls below a threshold, the gate
+/// closes and the iterator falls back to plain automaton scanning.
+#[derive(Clone)]
+pub struct PrefilterGate {
+    calls_in_window: u32,
+    gain_in_window: usize,
+    enabled: bool,
+}
+
+impl PrefilterGate {
+    /// The number of filter runs in one measurement window of [`PrefilterGate`].
+    const GATE_WINDOW_CALLS: u32 = 64;
+
+    /// The minimum number of bytes that filter runs in one measurement window must have skipped in
+    /// total. Below this, filtering is likely slower than plain automaton scanning.
+    const GATE_MIN_WINDOW_GAIN: usize = 8 * Self::GATE_WINDOW_CALLS as usize;
+
+    pub(crate) const fn new() -> Self {
+        Self {
+            calls_in_window: 0,
+            gain_in_window: 0,
+            enabled: true,
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) const fn is_enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// Records that a filter run let the automaton skip `gain` bytes.
+    #[inline(always)]
+    pub(crate) fn record(&mut self, gain: usize) {
+        self.calls_in_window += 1;
+        self.gain_in_window += gain;
+        if self.calls_in_window == Self::GATE_WINDOW_CALLS {
+            if self.gain_in_window < Self::GATE_MIN_WINDOW_GAIN {
+                self.enabled = false;
+            }
+            self.calls_in_window = 0;
+            self.gain_in_window = 0;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build(patterns: &[&[u8]]) -> Option<Prefilter> {
+        let mut builder = PrefilterBuilder::new();
+        for pattern in patterns {
+            builder.add(pattern);
+        }
+        builder.build()
+    }
+
+    #[test]
+    fn test_build_none_for_short_min_pattern() {
+        assert!(build(&[b"aqua", b"a"]).is_none());
+        assert!(build(&[b"aqua", b""]).is_none());
+    }
+
+    #[test]
+    fn test_build_none_for_empty_pattern_set() {
+        assert!(build(&[]).is_none());
+    }
+
+    #[test]
+    fn test_build_none_when_table_saturated() {
+        // All 2-byte patterns clear every table entry at position 0, making the expected
+        // candidate rate 1.
+        let mut builder = PrefilterBuilder::new();
+        for a in 0..=255u8 {
+            for b in 0..=255u8 {
+                builder.add(&[a, b]);
+            }
+        }
+        assert!(builder.build().is_none());
+    }
+
+    #[test]
+    fn test_long_pattern_windows_are_capped() {
+        // Patterns longer than MAX_WINDOW_LEN must not overflow the 8-bit table entries.
+        let long = b"undine".repeat(20);
+        let pf = build(&[&long, b"neovenezia"]).unwrap();
+        let mut haystack = vec![b'x'; 50];
+        haystack.extend_from_slice(&long);
+        assert_eq!(pf.next_position(&haystack, 0), 50);
+    }
+
+    #[test]
+    fn test_next_position_never_skips_occurrences() {
+        let patterns: &[&[u8]] = &[b"aria", b"rari", b"iaria", b"ariaariaaria"];
+        let pf = build(patterns).unwrap();
+        // A real occurrence must never lie before the returned position.
+        assert!(pf.next_position(b"iiiiariaii", 0) <= 4);
+        // Exhaustively check all haystacks over {a, r, i} up to length 8: walking a haystack
+        // candidate by candidate, no occurrence may start in a skipped section. Real
+        // occurrences are thus never passed over, since a candidate section is skipped only
+        // after being checked here.
+        for len in 0..=8u32 {
+            for haystack_code in 0..3usize.pow(len) {
+                let mut code = haystack_code;
+                let haystack: Vec<u8> = (0..len)
+                    .map(|_| {
+                        let c = b"ari"[code % 3];
+                        code /= 3;
+                        c
+                    })
+                    .collect();
+                let mut pos = 0;
+                while pos < haystack.len() {
+                    let candidate = pf.next_position(&haystack, pos);
+                    for start in pos..candidate {
+                        for pattern in patterns {
+                            assert_ne!(haystack.get(start..start + pattern.len()), Some(*pattern));
+                        }
+                    }
+                    pos = candidate + 1;
+                }
+                assert_eq!(pf.next_position(&haystack, haystack.len()), haystack.len());
+            }
+        }
+    }
+
+    #[test]
+    fn test_char_boundary_candidates() {
+        let patterns: &[&[u8]] = &["火星猫".as_bytes(), b"undine"];
+        let pf = build(patterns).unwrap();
+        let haystack = "アリア社長は火星猫で、灯里はundineの見習いです".as_bytes();
+        let mut pos = 0;
+        while pos < haystack.len() {
+            let candidate = pf.next_position_at_char_boundary(haystack, pos);
+            if candidate == haystack.len() {
+                break;
+            }
+            // Candidates are always on a character boundary.
+            assert_ne!(haystack[candidate] & 0xc0, 0x80);
+            for start in pos..candidate {
+                for pattern in patterns {
+                    assert_ne!(haystack.get(start..start + pattern.len()), Some(*pattern));
+                }
+            }
+            pos = candidate + 1;
+        }
+    }
+
+    #[test]
+    fn test_serialize_roundtrip() {
+        let pf = build(&[b"aqua", b"aria"]).unwrap();
+        let mut data = vec![];
+        pf.serialize_to_vec(&mut data);
+        assert_eq!(data.len(), Prefilter::serialized_bytes());
+        data.push(42);
+        let (other, rest) = Prefilter::deserialize_from_slice(&data).unwrap();
+        assert_eq!(&[42], rest);
+        assert!(pf == other);
+    }
+
+    #[test]
+    fn test_deserialize_rejects_invalid_data() {
+        let pf = build(&[b"gondola"]).unwrap();
+        let mut data = vec![];
+        pf.serialize_to_vec(&mut data);
+        // The window length must stay within its valid range.
+        for bad_window_len in [0, 1, 10, u8::MAX] {
+            let mut data = data.clone();
+            data[0] = bad_window_len;
+            assert!(Prefilter::deserialize_from_slice(&data).is_err());
+        }
+        // A truncated table must also be rejected.
+        assert!(Prefilter::deserialize_from_slice(&data[..data.len() - 1]).is_err());
+    }
+}

--- a/src/prefilter.rs
+++ b/src/prefilter.rs
@@ -89,6 +89,7 @@ impl Prefilter {
     }
 
     /// Returns the heap size of the filter table in bytes.
+    #[allow(clippy::unused_self)]
     pub const fn heap_bytes(&self) -> usize {
         Self::TABLE_LEN
     }
@@ -96,11 +97,12 @@ impl Prefilter {
     /// Estimates the probability that a uniformly random position in a random text becomes a
     /// candidate, as the product over all 2-gram positions of the fraction of 2-grams accepted
     /// there.
+    #[allow(clippy::as_conversions)]
     fn expected_candidate_rate(&self) -> f64 {
         let mut zeros = [0u32; 8];
         for &bits in self.table.iter() {
             for (i, n) in zeros.iter_mut().enumerate() {
-                *n += u32::from(bits >> i & 1 == 0);
+                *n += u32::from((bits >> i) & 1 == 0);
             }
         }
         let mut rate = 1.;
@@ -204,7 +206,7 @@ impl PrefilterGate {
 
     /// The minimum number of bytes that filter runs in one measurement window must have skipped in
     /// total. Below this, filtering is likely slower than plain automaton scanning.
-    const GATE_MIN_WINDOW_GAIN: usize = 8 * Self::GATE_WINDOW_CALLS as usize;
+    const GATE_MIN_WINDOW_GAIN: usize = 512;
 
     pub(crate) const fn new() -> Self {
         Self {

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -149,6 +149,8 @@ where
             src = rest;
         }
         Ok((
+            // Safety: dst is guaranteed to have exactly N elements, so the boxed slice can be
+            // converted to a [S; N] without any issues.
             unsafe { dst.into_boxed_slice().try_into().unwrap_unchecked() },
             src,
         ))

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -2,6 +2,7 @@
 
 use core::num::NonZeroU32;
 
+use alloc::boxed::Box;
 use alloc::vec::Vec;
 
 use crate::errors::{DaachorseError, Result};
@@ -127,6 +128,36 @@ where
 
     fn serialized_bytes(&self) -> usize {
         u32::serialized_bytes() + S::serialized_bytes() * self.len()
+    }
+}
+
+impl<S, const N: usize> SerializableVec for Box<[S; N]>
+where
+    S: Serializable,
+{
+    #[inline(always)]
+    fn serialize_to_vec(&self, dst: &mut Vec<u8>) {
+        self.iter().for_each(|x| x.serialize_to_vec(dst));
+    }
+
+    #[inline(always)]
+    fn deserialize_from_slice(mut src: &[u8]) -> Result<(Self, &[u8])> {
+        // To mitigate out-of-memory crashes when parsing a maliciously crafted automaton, restrict
+        // the memory allocation to not exceed the byte limit provided as an argument.
+        let mut dst = Vec::<S>::with_capacity(N);
+        for _ in 0..N {
+            let (x, rest) = S::deserialize_from_slice(src)?;
+            dst.push(x);
+            src = rest;
+        }
+        Ok((
+            unsafe { dst.into_boxed_slice().try_into().unwrap_unchecked() },
+            src,
+        ))
+    }
+
+    fn serialized_bytes(&self) -> usize {
+        N * S::serialized_bytes()
     }
 }
 

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -142,8 +142,6 @@ where
 
     #[inline(always)]
     fn deserialize_from_slice(mut src: &[u8]) -> Result<(Self, &[u8])> {
-        // To mitigate out-of-memory crashes when parsing a maliciously crafted automaton, restrict
-        // the memory allocation to not exceed the byte limit provided as an argument.
         let mut dst = Vec::<S>::with_capacity(N);
         for _ in 0..N {
             let (x, rest) = S::deserialize_from_slice(src)?;


### PR DESCRIPTION
This branch adds a Shift-OR with q-Grams prefilter.

The full implementation is in the `sog-prefilter` branch, but since it is huge, this pull request adds only the core parts of the feature.

Originally, a prefilter implementation was proposed in #151, but that implementation was a modification of ClamAV (GPLv2) code and could not be merged.

This implementation is a Shift-OR q-Grams filter implemented independently, following the paper by [Salmela et al. (2006)](https://dl.acm.org/doi/10.1145/1187436.1187438). The idea of the paper is to check whether the q-gram (also called an n-gram) at the current read position is contained in a table. The table records the occurrence positions of q-grams within the patterns as bit flags, and the input passes the filter if the conditions are satisfied through repeated Shift-OR operations.

Since this filter is effective for sparse matching, it needs to be disabled in the case of dense matching. The `PrefilterGate` tracks the match frequency, and once it exceeds a certain threshold, `is_enabled()` returns false.

# Performance comparison

Overlapping match [ms]
| Library | words_100 | words_5000 | words_15000 | words_100000 | cl100k | o200k | unidic |
| ------------------------ | --------:| --------:| --------:| ---------:| --------:| --------:| --------:|
| daachorse/bytewise | **1.12** | 2.08 | 2.08 | 8.00 | **11.63** | **12.46** | 22.49 |
| daachorse/charwise | 1.25 | **2.01** | **1.83** | **5.28** | N/A | N/A | 12.44 |
| aho_corasick/nfa | 2.01 | 9.34 | 9.74 | 12.04 | 29.86 | 33.72 | 40.72 |
| aho_corasick/dfa | 2.01 | 4.16 | 5.21 | 9.05 | 20.26 | 23.13 | 43.85 |
| yada | 6.97 | 9.81 | 10.20 | 11.08 | N/A | N/A | 22.53 |
| crawdad/trie | 8.10 | 10.10 | 10.20 | 10.35 | N/A | N/A | **12.22** |
| fst/map | 42.71 | 57.32 | 63.54 | 82.09 | 113.31 | 132.90 | 138.63 |

Shortest match [ms]
| Library | words_100 | words_5000 | words_15000 | words_100000 | cl100k | o200k | unidic |
| ------------------------ | --------:| --------:| --------:| ---------:| --------:| --------:| --------:|
| daachorse/bytewise | **1.07** | **2.04** | 2.00 | 6.92 | **2.06** | **2.07** | 2.39 |
| daachorse/charwise | 1.36 | 2.08 | **1.96** | **5.08** | N/A | N/A | **2.00** |
| aho_corasick/nfa | 1.50 | 8.64 | 9.20 | 10.91 | 33.05 | 33.27 | 18.06 |
| aho_corasick/dfa | 1.50 | 3.15 | 4.12 | 7.17 | 37.11 | 37.11 | 20.23 |

Leftmost longest match [ms]
| Library | words_100 | words_5000 | words_15000 | words_100000 | cl100k | o200k | unidic |
| ------------------------ | --------:| --------:| --------:| ---------:| --------:| --------:| --------:|
| daachorse/bytewise | **0.72** | **1.44** | **1.42** | 8.40 | **9.36** | **9.72** | 16.04 |
| daachorse/charwise | 0.79 | 1.52 | 1.46 | **5.73** | N/A | N/A | **10.67** |
| aho_corasick/nfa | 1.53 | 8.61 | 9.25 | 12.37 | 22.09 | 22.58 | 34.06 |
| aho_corasick/dfa | 1.53 | 3.23 | 4.24 | 8.88 | 20.71 | 21.57 | 40.58 |

Leftmost first match [ms]
| Library | words_100 | words_5000 | words_15000 | words_100000 | cl100k | o200k | unidic |
| ------------------------ | --------:| --------:| --------:| ---------:| --------:| --------:| --------:|
| daachorse/bytewise | **0.69** | **1.41** | **1.37** | 7.44 | **8.02** | **8.03** | 5.31 |
| daachorse/charwise | 0.81 | 1.56 | 1.48 | **5.66** | N/A | N/A | **4.17** |
| aho_corasick/nfa | 1.54 | 8.65 | 9.28 | 11.61 | 35.00 | 34.80 | 17.11 |
| aho_corasick/dfa | 1.53 | 3.24 | 4.22 | 8.11 | 37.23 | 37.26 | 18.51 |

Build [ms]
| Library | words_100 | words_5000 | words_15000 | words_100000 | cl100k | o200k | unidic |
| ------------------------ | --------:| --------:| --------:| ---------:| --------:| --------:| --------:|
| daachorse/bytewise | 0.25 | 8.23 | 21.36 | 260.66 | 77.02 | 156.97 | 698.45 |
| daachorse/charwise | 0.24 | 7.52 | 20.04 | 213.73 | N/A | N/A | 3070.90 |
| aho_corasick/nfa | 0.63 | 6.45 | 18.15 | 177.82 | 118.54 | 259.70 | 1303.60 |
| aho_corasick/dfa | 0.63 | 38.10 | 107.78 | 2286.50 | 1116.00 | 1963.20 | 8333.20 |
| yada | 0.56 | 34.46 | 69.11 | 928.92 | N/A | N/A | 1266.40 |
| crawdad/trie | 0.08 | 2.38 | 6.90 | 49.46 | N/A | N/A | 3271.50 |
| fst/map | 0.20 | 4.56 | 10.42 | 84.42 | 33.03 | 65.08 | 224.25 |